### PR TITLE
added SYSTEM attribute for Eigen3 include with gcc, to suppress depre…

### DIFF
--- a/lcDXFDWG/CMakeLists.txt
+++ b/lcDXFDWG/CMakeLists.txt
@@ -27,7 +27,11 @@ link_directories(${LOG4CXX_LIBRARY_DIRS})
 
 # Eigen 3
 find_package(Eigen3 REQUIRED)
-include_directories( ${EIGEN3_INCLUDE_DIR})
+if( CMAKE_COMPILER_IS_GNUCXX)
+    include_directories( SYSTEM ${EIGEN3_INCLUDE_DIR})
+else ()
+    include_directories( ${EIGEN3_INCLUDE_DIR})
+endif ()
 
 # BUILDING CONFIG
 # SEPERATE BUILDING FLAG

--- a/lcUI/CMakeLists.txt
+++ b/lcUI/CMakeLists.txt
@@ -66,7 +66,11 @@ link_directories(${LOG4CXX_LIBRARY_DIRS})
 
 # Eigen 3
 find_package(Eigen3 REQUIRED)
-include_directories( ${EIGEN3_INCLUDE_DIR})
+if( CMAKE_COMPILER_IS_GNUCXX)
+    include_directories( SYSTEM ${EIGEN3_INCLUDE_DIR})
+else ()
+    include_directories( ${EIGEN3_INCLUDE_DIR})
+endif ()
 
 # BUILDING CONFIG
 # SEPERATE BUILDING FLAG

--- a/lcadluascript/CMakeLists.txt
+++ b/lcadluascript/CMakeLists.txt
@@ -27,7 +27,11 @@ link_directories(${LUA_LIBRARY_DIRS})
 
 # Eigen 3
 find_package(Eigen3 REQUIRED)
-include_directories( ${EIGEN3_INCLUDE_DIR})
+if( CMAKE_COMPILER_IS_GNUCXX)
+    include_directories( SYSTEM ${EIGEN3_INCLUDE_DIR})
+else ()
+    include_directories( ${EIGEN3_INCLUDE_DIR})
+endif ()
 
 set(SEPARATE_BUILD OFF)
  

--- a/lckernel/CMakeLists.txt
+++ b/lckernel/CMakeLists.txt
@@ -149,7 +149,11 @@ link_directories(${LOG4CXX_LIBRARY_DIRS})
 
 # Eigen 3
 find_package(Eigen3 REQUIRED)
-include_directories( ${EIGEN3_INCLUDE_DIR})
+if( CMAKE_COMPILER_IS_GNUCXX)
+    include_directories( SYSTEM ${EIGEN3_INCLUDE_DIR})
+else ()
+    include_directories( ${EIGEN3_INCLUDE_DIR})
+endif ()
 
 # BUILDING CONFIG
 # SEPERATE BUILDING FLAG

--- a/lcviewernoqt/CMakeLists.txt
+++ b/lcviewernoqt/CMakeLists.txt
@@ -91,7 +91,11 @@ link_directories(${PANGO_LIBRARY_DIRS})
 
 # Eigen 3
 find_package(Eigen3 REQUIRED)
-include_directories( ${EIGEN3_INCLUDE_DIR})
+if( CMAKE_COMPILER_IS_GNUCXX)
+    include_directories( SYSTEM ${EIGEN3_INCLUDE_DIR})
+else ()
+    include_directories( ${EIGEN3_INCLUDE_DIR})
+endif ()
 
 # BUILDING CONFIG
 # SEPERATE BUILDING FLAG

--- a/lcviewerqt/CMakeLists.txt
+++ b/lcviewerqt/CMakeLists.txt
@@ -54,7 +54,11 @@ include_directories(${Boost_INCLUDE_DIRS})
 
 # Eigen 3
 find_package(Eigen3 REQUIRED)
-include_directories( ${EIGEN3_INCLUDE_DIR})
+if( CMAKE_COMPILER_IS_GNUCXX)
+    include_directories( SYSTEM ${EIGEN3_INCLUDE_DIR})
+else ()
+    include_directories( ${EIGEN3_INCLUDE_DIR})
+endif ()
 
 # BUILDING CONFIG
 # SEPERATE BUILDING FLAG

--- a/luacmdinterface/CMakeLists.txt
+++ b/luacmdinterface/CMakeLists.txt
@@ -30,7 +30,11 @@ link_directories(${LIBCURL_LIBRARY_DIRS})
 
 # Eigen 3
 find_package(Eigen3 REQUIRED)
-include_directories( ${EIGEN3_INCLUDE_DIR})
+if( CMAKE_COMPILER_IS_GNUCXX)
+    include_directories( SYSTEM ${EIGEN3_INCLUDE_DIR})
+else ()
+    include_directories( ${EIGEN3_INCLUDE_DIR})
+endif ()
 
 # Boost
 set(Boost_USE_MULTITHREADED ON)

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -15,7 +15,11 @@ link_directories(${LOG4CXX_LIBRARY_DIRS})
 
 # Eigen 3
 find_package(Eigen3 REQUIRED)
-include_directories( ${EIGEN3_INCLUDE_DIR})
+if( CMAKE_COMPILER_IS_GNUCXX)
+    include_directories( SYSTEM ${EIGEN3_INCLUDE_DIR})
+else ()
+    include_directories( ${EIGEN3_INCLUDE_DIR})
+endif ()
 
 FIND_PACKAGE ( Threads REQUIRED )
 


### PR DESCRIPTION
…cated warnings

These bunch of warnings with gcc version >= 6 are caused by Eigen3 headers using deprecated classes from standard library.
Set the Eigen3 include path as system makes gcc suppress these warnings.
Using Eigen3 with c++14 should be safe for now, but it will stop working with c++17.
