### PR TITLE
Remove CADEntity extension of LCVDrawItem

### DIFF
--- a/lcUI/cadmdichild.cpp
+++ b/lcUI/cadmdichild.cpp
@@ -222,8 +222,8 @@ LCViewer::TempEntities_SPtr CadMdiChild::tempEntities() {
     return _tempEntities;
 }
 
-std::vector<lc::entity::CADEntity_SPtr> CadMdiChild::selection() {
-    return viewer()->documentCanvas()->selection().asVector();
+std::vector<LCViewer::LCVDrawItem_SPtr> CadMdiChild::selection() {
+    return viewer()->documentCanvas()->selectedDrawables();
 }
 
 lc::Layer_CSPtr CadMdiChild::activeLayer() const {

--- a/lcUI/cadmdichild.cpp
+++ b/lcUI/cadmdichild.cpp
@@ -222,8 +222,8 @@ LCViewer::TempEntities_SPtr CadMdiChild::tempEntities() {
     return _tempEntities;
 }
 
-std::vector<LCViewer::LCVDrawItem_SPtr> CadMdiChild::selection() {
-    return viewer()->documentCanvas()->selectedDrawables();
+std::vector<lc::entity::CADEntity_CSPtr> CadMdiChild::selection() {
+    return viewer()->documentCanvas()->selectedEntities().asVector();
 }
 
 lc::Layer_CSPtr CadMdiChild::activeLayer() const {

--- a/lcUI/cadmdichild.h
+++ b/lcUI/cadmdichild.h
@@ -99,7 +99,7 @@ class CadMdiChild : public QWidget {
 		 * Return a vector of selected entities.
 		 * This function was added for Lua which can't access EntityContainer functions
 		 */
-        std::vector<LCViewer::LCVDrawItem_SPtr> selection();
+        std::vector<lc::entity::CADEntity_CSPtr> selection();
         void saveFile();
 
         /**

--- a/lcUI/cadmdichild.h
+++ b/lcUI/cadmdichild.h
@@ -99,7 +99,7 @@ class CadMdiChild : public QWidget {
 		 * Return a vector of selected entities.
 		 * This function was added for Lua which can't access EntityContainer functions
 		 */
-		std::vector<lc::entity::CADEntity_SPtr> selection();
+        std::vector<LCViewer::LCVDrawItem_SPtr> selection();
         void saveFile();
 
         /**

--- a/lckernel/cad/dochelpers/documentimpl.cpp
+++ b/lckernel/cad/dochelpers/documentimpl.cpp
@@ -150,7 +150,7 @@ StorageManager_SPtr DocumentImpl::storageManager() const {
 }
 
 
-EntityContainer<entity::CADEntity_CSPtr> DocumentImpl::entityContainer()  {
+EntityContainer<entity::CADEntity_CSPtr>& DocumentImpl::entityContainer()  {
     //   std::lock_guard<std::mutex> lck(_documentMutex);
     return _storageManager->entityContainer();
 }

--- a/lckernel/cad/dochelpers/documentimpl.h
+++ b/lckernel/cad/dochelpers/documentimpl.h
@@ -34,7 +34,7 @@ namespace lc {
 
             EntityContainer<entity::CADEntity_CSPtr> entitiesByBlock(Block_CSPtr block) override;
 
-            EntityContainer<entity::CADEntity_CSPtr> entityContainer() override;
+            EntityContainer<entity::CADEntity_CSPtr> &entityContainer() override;
 
             std::map<std::string, Layer_CSPtr> allLayers() const override;
 

--- a/lckernel/cad/dochelpers/entitycontainer.h
+++ b/lckernel/cad/dochelpers/entitycontainer.h
@@ -4,7 +4,6 @@
 #include <limits>
 #include <string>
 #include <vector>
-#include <drawitems/lcvdrawitem.h>
 
 #include "cad/const.h"
 #include "cad/base/id.h"
@@ -302,16 +301,7 @@ namespace lc {
                 // Now calculate for each entity if we are near the entities path
                 std::vector<lc::EntityDistance> entities;
                 for (auto item : ent) {
-                    Snapable_CSPtr entity;
-
-                    //TODO: remove this when EntityContainer will support LCVDrawItem
-                    auto drawable = std::dynamic_pointer_cast<const LCViewer::LCVDrawItem>(item);
-                    if (drawable) {
-                        entity = std::dynamic_pointer_cast<const lc::Snapable>(drawable->entity());
-                    }
-                    else {
-                        entity = std::dynamic_pointer_cast<const lc::Snapable>(item);
-                    }
+                    Snapable_CSPtr entity = std::dynamic_pointer_cast<const lc::Snapable>(item);
 
                     if (entity != nullptr) { // Not all entities might be snapable, so we only test if this is possible.
                         lc::geo::Coordinate eCoordinate = entity->nearestPointOnPath(point);

--- a/lckernel/cad/dochelpers/storagemanagerimpl.cpp
+++ b/lckernel/cad/dochelpers/storagemanagerimpl.cpp
@@ -68,7 +68,7 @@ std::map<std::string, Layer_CSPtr> StorageManagerImpl::allLayers() const {
     return data;
 }
 
-EntityContainer<entity::CADEntity_CSPtr> StorageManagerImpl::entityContainer() const {
+EntityContainer<entity::CADEntity_CSPtr> & StorageManagerImpl::entityContainer() {
     return _entities;
 }
 

--- a/lckernel/cad/dochelpers/storagemanagerimpl.h
+++ b/lckernel/cad/dochelpers/storagemanagerimpl.h
@@ -92,7 +92,7 @@ namespace lc {
              * @brief returns entity Container
              * @return entityContainer<entity::CADEntity_CSPtr>
              */
-            lc::EntityContainer<entity::CADEntity_CSPtr> entityContainer() const override;
+            EntityContainer<entity::CADEntity_CSPtr> &entityContainer() override;
 
             /**
             *  \brief add a document meta type

--- a/lckernel/cad/document/document.h
+++ b/lckernel/cad/document/document.h
@@ -190,7 +190,7 @@ namespace lc {
              * Return a copy of all entities within the document
              * @return
              */
-            virtual EntityContainer<entity::CADEntity_CSPtr> entityContainer() = 0;
+            virtual EntityContainer<entity::CADEntity_CSPtr>& entityContainer() = 0;
 
 
             /**

--- a/lckernel/cad/document/storagemanager.h
+++ b/lckernel/cad/document/storagemanager.h
@@ -49,7 +49,7 @@ namespace lc {
              * return a copy of all entities managed within the storage manager
              * \return
              */
-            virtual EntityContainer<entity::CADEntity_CSPtr> entityContainer() const = 0;
+            virtual EntityContainer<entity::CADEntity_CSPtr>& entityContainer() = 0;
 
             /**
             *  \brief add a document meta type

--- a/lckernel/cad/operations/entitybuilder.cpp
+++ b/lckernel/cad/operations/entitybuilder.cpp
@@ -22,10 +22,14 @@ EntityBuilder* EntityBuilder::appendOperation(Base_SPtr operation) {
 void EntityBuilder::processInternal() {
     processStack();
 
+    auto ec = document()->entityContainer();
+
     // Build a buffer with all entities we need to remove during a undo cycle
     for (auto entity : _workingBuffer) {
-        if (entity.get() != nullptr) {
-            _entitiesThatWhereUpdated.push_back(entity);
+        auto org = ec.entityByID(entity->id());
+
+        if (org.get() != nullptr) {
+            _entitiesThatWhereUpdated.push_back(org);
         }
     }
 

--- a/lckernel/cad/operations/entitybuilder.cpp
+++ b/lckernel/cad/operations/entitybuilder.cpp
@@ -22,14 +22,10 @@ EntityBuilder* EntityBuilder::appendOperation(Base_SPtr operation) {
 void EntityBuilder::processInternal() {
     processStack();
 
-    auto ec = document()->entityContainer();
-
     // Build a buffer with all entities we need to remove during a undo cycle
     for (auto entity : _workingBuffer) {
-        auto org = ec.entityByID(entity->id());
-
-        if (org.get() != nullptr) {
-            _entitiesThatWhereUpdated.push_back(org);
+        if (entity.get() != nullptr) {
+            _entitiesThatWhereUpdated.push_back(entity);
         }
     }
 

--- a/lcviewernoqt/documentcanvas.cpp
+++ b/lcviewernoqt/documentcanvas.cpp
@@ -606,7 +606,7 @@ LCVDrawItem_SPtr DocumentCanvas::asDrawable(lc::entity::CADEntity_CSPtr entity) 
     return nullptr;
 }
 
-std::vector<LCViewer::LCVDrawItem_SPtr> DocumentCanvas::selectedDrawables() {
+std::vector<LCViewer::LCVDrawItem_SPtr>& DocumentCanvas::selectedDrawables() {
     return _selectedDrawables;
 }
 

--- a/lcviewernoqt/documentcanvas.cpp
+++ b/lcviewernoqt/documentcanvas.cpp
@@ -366,6 +366,7 @@ void DocumentCanvas::on_commitProcessEvent(const lc::CommitProcessEvent&) {
     _document->entityContainer().optimise();
 }
 
+// This assumes that the entity has already been added to _document->entityContainer()
 void DocumentCanvas::on_addEntityEvent(const lc::AddEntityEvent& event) {
     auto entity = event.entity();
 
@@ -377,7 +378,6 @@ void DocumentCanvas::on_addEntityEvent(const lc::AddEntityEvent& event) {
 
     if (drawable != nullptr) {
         auto drawableEntity = std::dynamic_pointer_cast<LCViewer::LCVDrawItem>(drawable);
-        _document->entityContainer().insert(drawableEntity->entity());
         _entityDrawItem.insert(std::make_pair(drawableEntity->entity(), drawableEntity));
     }
 }

--- a/lcviewernoqt/documentcanvas.cpp
+++ b/lcviewernoqt/documentcanvas.cpp
@@ -391,7 +391,7 @@ std::shared_ptr<lc::Document> DocumentCanvas::document() const {
     return _document;
 }
 
-const lc::EntityContainer<lc::entity::CADEntity_CSPtr>& DocumentCanvas::entityContainer() const {
+lc::EntityContainer<lc::entity::CADEntity_CSPtr>& DocumentCanvas::entityContainer() const {
     return _document->entityContainer();
 }
 

--- a/lcviewernoqt/documentcanvas.cpp
+++ b/lcviewernoqt/documentcanvas.cpp
@@ -154,7 +154,7 @@ void DocumentCanvas::zoom(LcPainter& painter, double factor, bool relativezoom, 
 }
 
 void DocumentCanvas::autoScale(LcPainter& painter) {
-    auto extends = _entityContainer.boundingBox();
+    auto extends = _document->entityContainer().boundingBox();
     extends = extends.increaseBy(std::min(extends.width(), extends.height()) * 0.1);
 
     setDisplayArea(painter, extends);
@@ -200,11 +200,16 @@ void DocumentCanvas::render(LcPainter& painter, PainterType type) {
             painter.lineWidthCompensation(0.5);
             painter.enable_antialias();
 
-            auto visibleItems = _entityContainer.entitiesWithinAndCrossingAreaFast(visibleUserArea);
-
-            visibleItems.each<LCVDrawItem>([&](LCVDrawItem_CSPtr di) {
-                drawEntity(painter, di);
+            auto visibleEntities = _document->entityContainer().entitiesWithinAndCrossingAreaFast(visibleUserArea);
+            std::vector<LCViewer::LCVDrawItem_SPtr> visibleDrawables;
+            visibleEntities.each< const lc::entity::CADEntity >([&](lc::entity::CADEntity_CSPtr entity) {
+                auto di = _entityDrawItem[entity];
+                visibleDrawables.push_back(di);
             });
+
+            for(auto di: visibleDrawables) {
+                drawEntity(painter, di);
+            };
             painter.line_width(1.);
             painter.source_rgb(1., 1., 1.);
             painter.lineWidthCompensation(0.);
@@ -306,7 +311,7 @@ lc::Color DocumentCanvas::drawColor(lc::entity::CADEntity_CSPtr entity, lc::enti
     }
 }
 
-void DocumentCanvas::drawEntity(LcPainter& painter, LCVDrawItem_CSPtr entity, lc::entity::Insert_CSPtr insert) {
+void DocumentCanvas::drawEntity(LcPainter& painter, LCVDrawItem_CSPtr drawable, lc::entity::Insert_CSPtr insert) {
     LcDrawOptions lcDrawOptions;
 
     double x = 0.;
@@ -317,7 +322,7 @@ void DocumentCanvas::drawEntity(LcPainter& painter, LCVDrawItem_CSPtr entity, lc
     painter.device_to_user_distance(&w, &h);
     lc::geo::Area visibleUserArea = lc::geo::Area(lc::geo::Coordinate(x, y), w, h);
 
-    auto asInsert = std::dynamic_pointer_cast<const LCVInsert>(entity);
+    auto asInsert = std::dynamic_pointer_cast<const LCVInsert>(drawable);
     if(asInsert != nullptr) {
         asInsert->draw(shared_from_this(), painter);
         return;
@@ -325,7 +330,7 @@ void DocumentCanvas::drawEntity(LcPainter& painter, LCVDrawItem_CSPtr entity, lc
 
     painter.save();
 
-	lc::entity::CADEntity_CSPtr ci = std::dynamic_pointer_cast<const lc::entity::CADEntity>(entity);
+    lc::entity::CADEntity_CSPtr ci = drawable->entity();
 
 
 	// Used to give the illusation from slightly thinner lines. Not sure yet what to d with it and if I will keep it
@@ -344,7 +349,7 @@ void DocumentCanvas::drawEntity(LcPainter& painter, LCVDrawItem_CSPtr entity, lc
 
 	// Decide what color to render the entity into
 
-    auto color = drawColor(ci, insert, entity->selected());
+    auto color = drawColor(ci, insert, drawable->selected());
     painter.source_rgba(
             color.red(),
             color.green(),
@@ -352,13 +357,13 @@ void DocumentCanvas::drawEntity(LcPainter& painter, LCVDrawItem_CSPtr entity, lc
             color.alpha() * alpha_compensation
     );
 
-	entity->draw(painter, lcDrawOptions, visibleUserArea);
+    drawable->draw(painter, lcDrawOptions, visibleUserArea);
 
 	painter.restore();	
 }
 
 void DocumentCanvas::on_commitProcessEvent(const lc::CommitProcessEvent&) {
-    _entityContainer.optimise();
+    _document->entityContainer().optimise();
 }
 
 void DocumentCanvas::on_addEntityEvent(const lc::AddEntityEvent& event) {
@@ -371,27 +376,27 @@ void DocumentCanvas::on_addEntityEvent(const lc::AddEntityEvent& event) {
     auto drawable = asDrawable(event.entity());
 
     if (drawable != nullptr) {
-		auto drawableEntity = std::dynamic_pointer_cast<lc::entity::CADEntity>(drawable);
-        _entityContainer.insert(drawableEntity);
+        auto drawableEntity = std::dynamic_pointer_cast<LCViewer::LCVDrawItem>(drawable);
+        _document->entityContainer().insert(drawableEntity->entity());
+        _entityDrawItem.insert(std::make_pair(drawableEntity->entity(), drawableEntity));
     }
 }
 
 void DocumentCanvas::on_removeEntityEvent(const lc::RemoveEntityEvent& event) {
-    auto i = _entityContainer.entityByID(event.entity()->id());
-
-    _entityContainer.remove(i);
+    _document->entityContainer().remove(event.entity());
+    _entityDrawItem.erase(event.entity());
 }
 
 std::shared_ptr<lc::Document> DocumentCanvas::document() const {
     return _document;
 }
 
-const lc::EntityContainer<lc::entity::CADEntity_SPtr>& DocumentCanvas::entityContainer() const {
-    return _entityContainer;
+const lc::EntityContainer<lc::entity::CADEntity_CSPtr>& DocumentCanvas::entityContainer() const {
+    return _document->entityContainer();
 }
 
 lc::geo::Area DocumentCanvas::bounds() const {
-    return _entityContainer.bounds();
+    return _document->entityContainer().bounds();
 }
 
 void DocumentCanvas::makeSelection(double x, double y, double w, double h, bool occupies) {
@@ -404,30 +409,38 @@ void DocumentCanvas::makeSelection(double x, double y, double w, double h, bool 
     // std::cout << *_selectedArea << std::endl;
     _selectedAreaIntersects = occupies;
 
-    _newSelection.each< LCVDrawItem >([](LCVDrawItem_SPtr di) {
+
+    for(auto di: _newSelection) {
         di->selected(false);
-    });
-
-    _selectedEntities.each< LCVDrawItem >([](LCVDrawItem_SPtr di) {
-        di->selected(true);
-    });
-
-    if (occupies) {
-        _newSelection = _entityContainer.entitiesFullWithinArea(*_selectedArea);
-    } else {
-        _newSelection = _entityContainer.entitiesWithinAndCrossingArea(*_selectedArea);
     }
 
-    _newSelection.each< LCVDrawItem >([&](LCVDrawItem_SPtr di) {
-        // std::cerr<< __FILE__ << " : " << __FUNCTION__ << " : " << __LINE__ << " " << typeid(*di).name() << std::endl;
-        auto entity = std::dynamic_pointer_cast<lc::entity::CADEntity>(di);
-        if(entity && _selectedEntities.entityByID(entity->id()) != nullptr) {
+    for(auto di: _selectedDrawables) {
+        di->selected(true);
+    }
+
+    lc::EntityContainer<lc::entity::CADEntity_CSPtr> entitiesInSelection;
+
+    if (occupies) {
+        entitiesInSelection = _document->entityContainer().entitiesFullWithinArea(*_selectedArea);
+    } else {
+        entitiesInSelection = _document->entityContainer().entitiesWithinAndCrossingArea(*_selectedArea);
+    }
+    _newSelection.clear();
+    entitiesInSelection.each< const lc::entity::CADEntity >([&](lc::entity::CADEntity_CSPtr entity) {
+        auto di = _entityDrawItem[entity];
+        auto iter = std::find(_selectedDrawables.begin(), _selectedDrawables.end(), di);
+        _newSelection.push_back(di);
+        if(entity && iter != _selectedDrawables.end()) {
             di->selected(false);
         }
         else {
             di->selected(true);
         }
     });
+}
+
+LCViewer::LCVDrawItem_SPtr DocumentCanvas::getDrawable(lc::entity::CADEntity_CSPtr entity) {
+    return _entityDrawItem[entity];
 }
 
 void DocumentCanvas::makeSelectionDevice(LcPainter& painter, unsigned int x, unsigned int y, unsigned int w, unsigned int h, bool occupies) {
@@ -446,20 +459,19 @@ void DocumentCanvas::makeSelectionDevice(LcPainter& painter, unsigned int x, uns
 }
 
 void DocumentCanvas::closeSelection() {
-    _newSelection.each<lc::entity::CADEntity>([&](lc::entity::CADEntity_SPtr entity) {
-        auto drawable = std::dynamic_pointer_cast<LCVDrawItem>(entity);
-
-        if(_selectedEntities.entityByID(entity->id()) != nullptr) {
-            _selectedEntities.remove(entity);
+    for(auto drawable: _newSelection) {
+        auto iter = std::find(_selectedDrawables.begin(), _selectedDrawables.end(), drawable);
+        if(iter != _selectedDrawables.end()) {
             drawable->selected(false);
+            _selectedDrawables.erase(iter);
         }
         else {
-            _selectedEntities.insert(entity);
             drawable->selected(true);
+            _selectedDrawables.push_back(drawable);
         }
-    });
+    };
 
-    _newSelection = lc::EntityContainer<lc::entity::CADEntity_SPtr>();
+    _newSelection.clear();
 }
 
 void DocumentCanvas::removeSelectionArea() {
@@ -470,11 +482,11 @@ void DocumentCanvas::removeSelectionArea() {
 }
 
 void DocumentCanvas::removeSelection() {
-    _selectedEntities.each< LCVDrawItem >([](LCVDrawItem_SPtr di) {
+    for(auto di: _selectedDrawables) {
         di->selected(false);
-    });
+    };
 
-    _selectedEntities = lc::EntityContainer<lc::entity::CADEntity_SPtr>();
+    _selectedDrawables.clear();
 }
 
 Nano::Signal<void(DrawEvent const & event)> & DocumentCanvas::background ()  {
@@ -594,8 +606,16 @@ LCVDrawItem_SPtr DocumentCanvas::asDrawable(lc::entity::CADEntity_CSPtr entity) 
     return nullptr;
 }
 
-lc::EntityContainer<lc::entity::CADEntity_SPtr> DocumentCanvas::selection() {
-    return _selectedEntities;
+std::vector<LCViewer::LCVDrawItem_SPtr> DocumentCanvas::selectedDrawables() {
+    return _selectedDrawables;
+}
+
+lc::EntityContainer<lc::entity::CADEntity_CSPtr> DocumentCanvas::selectedEntities() {
+    lc::EntityContainer<lc::entity::CADEntity_CSPtr> entitiesInSelection;
+    for(auto di: _selectedDrawables) {
+        entitiesInSelection.insert(di->entity());
+    }
+    return entitiesInSelection;
 }
 
 void DocumentCanvas::newDeviceSize(unsigned int width, unsigned int height) {
@@ -613,8 +633,8 @@ void DocumentCanvas::selectPoint(double x, double y) {
     w = w - zeroX;
 
     lc::geo::Area selectionArea(lc::geo::Coordinate(x - w, y - w), w * 2, w * 2);
-    auto entities = _entityContainer.entitiesWithinAndCrossingAreaFast(selectionArea);
-    entities.each<LCVDrawItem>([](LCVDrawItem_SPtr entity) {
-        entity->selected(!entity->selected());
+    auto entities = _document->entityContainer().entitiesWithinAndCrossingAreaFast(selectionArea);
+    entities.each< const lc::entity::CADEntity >([=](lc::entity::CADEntity_CSPtr entity) {
+        _entityDrawItem[entity]->selected(!_entityDrawItem[entity]->selected());
     });
 }

--- a/lcviewernoqt/documentcanvas.h
+++ b/lcviewernoqt/documentcanvas.h
@@ -161,7 +161,7 @@ namespace LCViewer {
          * Get the current entity container,
          * do not store this as a reference, always call it
          */
-        const lc::EntityContainer<lc::entity::CADEntity_CSPtr>& entityContainer() const;
+        lc::EntityContainer<lc::entity::CADEntity_CSPtr>& entityContainer() const;
 
         /**
          * Return CADEntity as LCVDrawItem

--- a/lcviewernoqt/documentcanvas.h
+++ b/lcviewernoqt/documentcanvas.h
@@ -139,7 +139,7 @@ namespace LCViewer {
 
         void removeSelection();
 
-        std::vector<LCViewer::LCVDrawItem_SPtr> selectedDrawables();
+        std::vector<LCViewer::LCVDrawItem_SPtr>& selectedDrawables();
         lc::EntityContainer<lc::entity::CADEntity_CSPtr> selectedEntities();
 
         /**

--- a/lcviewernoqt/documentcanvas.h
+++ b/lcviewernoqt/documentcanvas.h
@@ -139,7 +139,8 @@ namespace LCViewer {
 
         void removeSelection();
 
-        lc::EntityContainer<lc::entity::CADEntity_SPtr> selection();
+        std::vector<LCViewer::LCVDrawItem_SPtr> selectedDrawables();
+        lc::EntityContainer<lc::entity::CADEntity_CSPtr> selectedEntities();
 
         /**
          *
@@ -160,7 +161,7 @@ namespace LCViewer {
          * Get the current entity container,
          * do not store this as a reference, always call it
          */
-        const lc::EntityContainer<lc::entity::CADEntity_SPtr>& entityContainer() const;
+        const lc::EntityContainer<lc::entity::CADEntity_CSPtr>& entityContainer() const;
 
         /**
          * Return CADEntity as LCVDrawItem
@@ -181,6 +182,8 @@ namespace LCViewer {
          */
         void selectPoint(double x, double y);
 
+        LCViewer::LCVDrawItem_SPtr getDrawable(lc::entity::CADEntity_CSPtr entity);
+
     private:
         void on_addEntityEvent(const lc::AddEntityEvent&);
         void on_removeEntityEvent(const lc::RemoveEntityEvent&);
@@ -197,8 +200,8 @@ namespace LCViewer {
         // Original document
         std::shared_ptr<lc::Document> _document;
 
-        // Local entity container
-        lc::EntityContainer<lc::entity::CADEntity_SPtr> _entityContainer;
+        // Map of cad entity to drawitem
+        std::map<lc::entity::CADEntity_CSPtr, LCViewer::LCVDrawItem_SPtr> _entityDrawItem;
 
         Nano::Signal<void(DrawEvent const & event)> _background;
         Nano::Signal<void(DrawEvent const & event)> _foreground;
@@ -221,8 +224,8 @@ namespace LCViewer {
         // Functor to draw a selected area, that's the green or read area...
         std::function<void(LcPainter&, lc::geo::Area, bool)> _selectedAreaPainter;
 
-        lc::EntityContainer<lc::entity::CADEntity_SPtr> _selectedEntities;
-        lc::EntityContainer<lc::entity::CADEntity_SPtr> _newSelection;
+        std::vector<LCViewer::LCVDrawItem_SPtr> _selectedDrawables;
+        std::vector<LCViewer::LCVDrawItem_SPtr> _newSelection;
 
         std::function<void(double*, double*)> _deviceToUser;
     };

--- a/lcviewernoqt/drawables/tempentities.cpp
+++ b/lcviewernoqt/drawables/tempentities.cpp
@@ -6,10 +6,7 @@ TempEntities::TempEntities(DocumentCanvas_SPtr docCanvas) : _docCanvas(docCanvas
 }
 
 void TempEntities::addEntity(lc::entity::CADEntity_CSPtr entity) {
-
-	auto drawable = _docCanvas->asDrawable(entity);
-
-	_entities.insert(std::dynamic_pointer_cast<const lc::entity::CADEntity>(drawable));
+    _entities.insert(entity);
 }
 
 void TempEntities::removeEntity(lc::entity::CADEntity_CSPtr entity) {
@@ -17,7 +14,7 @@ void TempEntities::removeEntity(lc::entity::CADEntity_CSPtr entity) {
 }
 
 void TempEntities::onDraw(DrawEvent const &event) {
-	_entities.each<const LCViewer::LCVDrawItem>([&](LCViewer::LCVDrawItem_CSPtr entity) {
-		_docCanvas->drawEntity(event.painter(), entity);
+    _entities.each<const lc::entity::CADEntity>([&](lc::entity::CADEntity_CSPtr entity) {
+        _docCanvas->drawEntity(event.painter(), _docCanvas->asDrawable(entity));
 	});
 }

--- a/lcviewernoqt/drawitems/lcvdrawitem.cpp
+++ b/lcviewernoqt/drawitems/lcvdrawitem.cpp
@@ -2,7 +2,6 @@
 using namespace LCViewer;
 
 LCVDrawItem::LCVDrawItem(lc::entity::CADEntity_CSPtr entity, bool selectable) :
-        CADEntity(entity, true),
         _selectable(selectable),
         _selected(false) {
 
@@ -18,37 +17,4 @@ bool LCVDrawItem::selected() const {
 
 void LCVDrawItem::selected(bool selected) {
     _selected = selected;
-}
-
-lc::entity::CADEntity_CSPtr LCVDrawItem::move(const lc::geo::Coordinate& offset) const {
-    return entity()->move(offset);
-}
-
-lc::entity::CADEntity_CSPtr LCVDrawItem::copy(const lc::geo::Coordinate& offset) const {
-    return entity()->copy(offset);
-}
-
-lc::entity::CADEntity_CSPtr LCVDrawItem::rotate(const lc::geo::Coordinate& rotation_center, const double rotation_angle) const {
-    return entity()->rotate(rotation_center, rotation_angle);
-}
-
-lc::entity::CADEntity_CSPtr LCVDrawItem::scale(const lc::geo::Coordinate& scale_center, const lc::geo::Coordinate& scale_factor) const {
-    return entity()->scale(scale_center, scale_factor);
-}
-
-lc::entity::CADEntity_CSPtr LCVDrawItem::mirror(const lc::geo::Coordinate& axis1, const lc::geo::Coordinate& axis2) const {
-    return entity()->mirror(axis1, axis2);
-}
-
-const lc::geo::Area LCVDrawItem::boundingBox() const {
-    return entity()->boundingBox();
-}
-
-lc::entity::CADEntity_CSPtr
-LCVDrawItem::modify(lc::Layer_CSPtr layer, const lc::MetaInfo_CSPtr metaInfo, lc::Block_CSPtr block) const {
-    return entity()->modify(layer, metaInfo, lc::Block_CSPtr());
-}
-
-void LCVDrawItem::dispatch(lc::EntityDispatch& dispatch) const {
-    entity()->dispatch(dispatch);
 }

--- a/lcviewernoqt/drawitems/lcvdrawitem.h
+++ b/lcviewernoqt/drawitems/lcvdrawitem.h
@@ -20,7 +20,7 @@ namespace LCViewer {
      * For other objects (Cursor, ...) see files in drawables folder
      * LCVDrawItem is a child of CADEntity as it's the only way to store it in EntityContainer
      */
-    class LCVDrawItem : public lc::entity::CADEntity {
+    class LCVDrawItem {
         public:
             LCVDrawItem(lc::entity::CADEntity_CSPtr entity, bool selectable);
 
@@ -42,16 +42,6 @@ namespace LCViewer {
              * @return Entity
              */
             virtual lc::entity::CADEntity_CSPtr entity() const = 0;
-
-            //CADEntity functions
-            lc::entity::CADEntity_CSPtr move(const lc::geo::Coordinate& offset) const override;
-            lc::entity::CADEntity_CSPtr copy(const lc::geo::Coordinate& offset) const override;
-            lc::entity::CADEntity_CSPtr rotate(const lc::geo::Coordinate& rotation_center, const double rotation_angle) const override;
-            lc::entity::CADEntity_CSPtr scale(const lc::geo::Coordinate& scale_center, const lc::geo::Coordinate& scale_factor) const override;
-            lc::entity::CADEntity_CSPtr mirror(const lc::geo::Coordinate& axis1, const lc::geo::Coordinate& axis2) const override;const lc::geo::Area boundingBox() const override;
-            lc::entity::CADEntity_CSPtr
-            modify(lc::Layer_CSPtr layer, const lc::MetaInfo_CSPtr metaInfo, lc::Block_CSPtr block) const override;
-            void dispatch(lc::EntityDispatch& dispatch) const override;
 
         private:
             bool _selectable;

--- a/lcviewernoqt/managers/dragmanager.cpp
+++ b/lcviewernoqt/managers/dragmanager.cpp
@@ -132,19 +132,15 @@ void DragManager::onMousePress() {
 	_entityBuilder = std::make_shared<lc::operation::EntityBuilder>(_docCanvas->document());
 	_builder->append(_entityBuilder);
 
-    auto entities = _docCanvas->selectedDrawables();
-    if(entities.size() == 0) {
+    std::vector<LCViewer::LCVDrawItem_SPtr> selectedDrawables = _docCanvas->selectedDrawables();
+    if(selectedDrawables.size() == 0) {
         auto entitiesInSelection = _docCanvas->document()->entityContainer().entitiesWithinAndCrossingAreaFast(_toleranceArea);
         entitiesInSelection.each< const lc::entity::CADEntity >([&](lc::entity::CADEntity_CSPtr entity) {
-            entities.push_back(_docCanvas->getDrawable(entity));
+            selectedDrawables.push_back(_docCanvas->getDrawable(entity));
         });
     }
 
-    for(auto entity : entities) {
-		auto drawable = std::dynamic_pointer_cast<const LCVDrawItem>(entity);
-		if(!drawable) {
-            continue;
-		}
+    for(auto drawable : selectedDrawables) {
 
 		auto draggable = std::dynamic_pointer_cast<const lc::Draggable>(drawable->entity());
 		if(draggable) {
@@ -160,7 +156,7 @@ void DragManager::onMousePress() {
 						unmanagedDraggable->onDragPointClick(_builder, point.first);
 					}
 					else {
-						_entityBuilder->appendEntity(drawable->entity());
+                        _entityBuilder->appendEntity(drawable->entity());
 					}
 
 					break;

--- a/unittest/lcviewernoqt/testselection.cpp
+++ b/unittest/lcviewernoqt/testselection.cpp
@@ -27,17 +27,17 @@ TEST(SelectionTest, NormalSelection) {
 	docCanvas->makeSelection(0, 0, 5, 10, true);
 	docCanvas->closeSelection();
 
-	EXPECT_EQ(1, docCanvas->selection().asVector().size());
+    EXPECT_EQ(1, docCanvas->selectedDrawables().size());
 
 	unsigned int i = 0;
 
-	docCanvas->entityContainer().each<LCViewer::LCVDrawItem>([&](LCViewer::LCVDrawItem_CSPtr di) {
-		if(di->selected()) {
+    docCanvas->entityContainer().each<const lc::entity::CADEntity>([&](lc::entity::CADEntity_CSPtr di) {
+        if(docCanvas->getDrawable(di)->selected()) {
 			i++;
 		}
 	});
 
-	EXPECT_TRUE(i == docCanvas->selection().asVector().size());
+    EXPECT_TRUE(i == docCanvas->selectedDrawables().size());
 }
 
 TEST(SelectionTest, IntersectionSelection) {
@@ -57,17 +57,17 @@ TEST(SelectionTest, IntersectionSelection) {
 	docCanvas->makeSelection(0, 0, 5, 5, false);
 	docCanvas->closeSelection();
 
-	EXPECT_EQ(1, docCanvas->selection().asVector().size());
+    EXPECT_EQ(1, docCanvas->selectedDrawables().size());
 
-	unsigned int i = 0;
+    unsigned int i = 0;
 
-	docCanvas->entityContainer().each<LCViewer::LCVDrawItem>([&](LCViewer::LCVDrawItem_CSPtr di) {
-		if(di->selected() == true) {
-			i++;
-		}
-	});
+    docCanvas->entityContainer().each<const lc::entity::CADEntity>([&](lc::entity::CADEntity_CSPtr di) {
+        if(docCanvas->getDrawable(di)->selected()) {
+            i++;
+        }
+    });
 
-	EXPECT_TRUE(i == docCanvas->selection().asVector().size());
+    EXPECT_TRUE(i == docCanvas->selectedDrawables().size());
 }
 
 TEST(SelectionTest, AddToSelection) {
@@ -90,17 +90,17 @@ TEST(SelectionTest, AddToSelection) {
 	docCanvas->makeSelection(9, 0, 1, 1, false);
 	docCanvas->closeSelection();
 
-	EXPECT_EQ(2, docCanvas->selection().asVector().size());
+    EXPECT_EQ(2, docCanvas->selectedDrawables().size());
 
-	unsigned int i = 0;
+    unsigned int i = 0;
 
-	docCanvas->entityContainer().each<LCViewer::LCVDrawItem>([&](LCViewer::LCVDrawItem_CSPtr di) {
-		if(di->selected() == true) {
-			i++;
-		}
-	});
+    docCanvas->entityContainer().each<const lc::entity::CADEntity>([&](lc::entity::CADEntity_CSPtr di) {
+        if(docCanvas->getDrawable(di)->selected()) {
+            i++;
+        }
+    });
 
-	EXPECT_TRUE(i == docCanvas->selection().asVector().size());
+    EXPECT_TRUE(i == docCanvas->selectedDrawables().size());
 }
 
 TEST(SelectionTest, Reselect) {
@@ -123,17 +123,17 @@ TEST(SelectionTest, Reselect) {
 	docCanvas->makeSelection(9, 0, 1, 1, false);
 	docCanvas->closeSelection();
 
-	EXPECT_EQ(1, docCanvas->selection().asVector().size());
+    EXPECT_EQ(1, docCanvas->selectedDrawables().size());
 
-	unsigned int i = 0;
+    unsigned int i = 0;
 
-	docCanvas->entityContainer().each<LCViewer::LCVDrawItem>([&](LCViewer::LCVDrawItem_CSPtr di) {
-		if(di->selected() == true) {
-			i++;
-		}
-	});
+    docCanvas->entityContainer().each<const lc::entity::CADEntity>([&](lc::entity::CADEntity_CSPtr di) {
+        if(docCanvas->getDrawable(di)->selected()) {
+            i++;
+        }
+    });
 
-	EXPECT_TRUE(i == docCanvas->selection().asVector().size());
+    EXPECT_TRUE(i == docCanvas->selectedDrawables().size());
 }
 
 TEST(SelectionTest, ClearSelection) {
@@ -156,17 +156,17 @@ TEST(SelectionTest, ClearSelection) {
 	docCanvas->makeSelection(9, 0, 1, 1, false);
 	docCanvas->closeSelection();
 
-	EXPECT_EQ(2, docCanvas->selection().asVector().size());
+    EXPECT_EQ(2, docCanvas->selectedDrawables().size());
 
-	unsigned int i = 0;
+    unsigned int i = 0;
 
-	docCanvas->entityContainer().each<LCViewer::LCVDrawItem>([&](LCViewer::LCVDrawItem_CSPtr di) {
-		if(di->selected() == true) {
-			i++;
-		}
-	});
+    docCanvas->entityContainer().each<const lc::entity::CADEntity>([&](lc::entity::CADEntity_CSPtr di) {
+        if(docCanvas->getDrawable(di)->selected()) {
+            i++;
+        }
+    });
 
-	EXPECT_TRUE(i == docCanvas->selection().asVector().size());
+    EXPECT_TRUE(i == docCanvas->selectedDrawables().size());
 }
 
 TEST(SelectionTest, Deselect) {
@@ -187,17 +187,17 @@ TEST(SelectionTest, Deselect) {
 	docCanvas->makeSelection(-1, -1, 0, 0, false);
 	docCanvas->closeSelection();
 
-	EXPECT_EQ(0, docCanvas->selection().asVector().size());
+    EXPECT_EQ(0, docCanvas->selectedDrawables().size());
 
-	unsigned int i = 0;
+    unsigned int i = 0;
 
-	docCanvas->entityContainer().each<LCViewer::LCVDrawItem>([&](LCViewer::LCVDrawItem_CSPtr di) {
-		if(di->selected() == true) {
-			i++;
-		}
-	});
+    docCanvas->entityContainer().each<const lc::entity::CADEntity>([&](lc::entity::CADEntity_CSPtr di) {
+        if(docCanvas->getDrawable(di)->selected()) {
+            i++;
+        }
+    });
 
-	EXPECT_TRUE(i == docCanvas->selection().asVector().size());
+    EXPECT_TRUE(i == docCanvas->selectedDrawables().size());
 }
 
 TEST(SelectionTest, DeselectAddTo) {
@@ -221,15 +221,15 @@ TEST(SelectionTest, DeselectAddTo) {
 	docCanvas->makeSelection(11, 0, 0, 0, false);
 	docCanvas->closeSelection();
 
-	EXPECT_EQ(1, docCanvas->selection().asVector().size());
+    EXPECT_EQ(1, docCanvas->selectedDrawables().size());
 
-	unsigned int i = 0;
+    unsigned int i = 0;
 
-	docCanvas->entityContainer().each<LCViewer::LCVDrawItem>([&](LCViewer::LCVDrawItem_CSPtr di) {
-		if(di->selected() == true) {
-			i++;
-		}
-	});
+    docCanvas->entityContainer().each<const lc::entity::CADEntity>([&](lc::entity::CADEntity_CSPtr di) {
+        if(docCanvas->getDrawable(di)->selected()) {
+            i++;
+        }
+    });
 
-	EXPECT_TRUE(i == docCanvas->selection().asVector().size());
+    EXPECT_TRUE(i == docCanvas->selectedDrawables().size());
 }


### PR DESCRIPTION
Use a map to keep the entities in the document->storageManager and the drawable items in sync