### PR TITLE
Request the layers map once in buildertest

### DIFF
--- a/unittest/lckernel/operations/buildertest.cpp
+++ b/unittest/lckernel/operations/buildertest.cpp
@@ -29,8 +29,9 @@ TEST(BuilderTest, Process) {
     EXPECT_EQ(1, document->blocks().size());
     EXPECT_EQ(block, *document->blocks().begin());
 
-    EXPECT_EQ(2, document->allLayers().size());
-    auto it = document->allLayers().begin();
+    auto layers = document->allLayers();
+    EXPECT_EQ(2, layers.size());
+    auto it = layers.begin();
     auto layer1 = it->second;
     it++;
     auto layer2 = it->second;
@@ -95,8 +96,9 @@ TEST(BuilderTest, Redo) {
     EXPECT_EQ(1, document->blocks().size());
     EXPECT_EQ(block, *document->blocks().begin());
 
-    EXPECT_EQ(2, document->allLayers().size());
-    auto it = document->allLayers().begin();
+    auto layers = document->allLayers();
+    EXPECT_EQ(2, layers.size());
+    auto it = layers.begin();
     auto layer1 = it->second;
     it++;
     auto layer2 = it->second;


### PR DESCRIPTION
Otherwise the test crashes on macos/clang 