### PR TITLE
Message asking for second point of line fixed.

### DIFF
--- a/lcUILua/createActions/lineoperations.lua
+++ b/lcUILua/createActions/lineoperations.lua
@@ -40,7 +40,7 @@ function LineOperations:newPoint(point)
         CreateOperations.close(self)
     else
         self.lastPoint = point
-        message("Click on second point or enter line length")
+        message("Click on second point or enter line length", self.target_widget)
     end
 end
 


### PR DESCRIPTION
While creating line, after clicking the first point, "Click on second point or enter line length" message was not seen. There was an error in message function.