### PR TITLE
Workaround for raw text from  cli_get_text(self.target_widget, true)

### DIFF
--- a/lcUI/lua/qtbridge.cpp
+++ b/lcUI/lua/qtbridge.cpp
@@ -231,6 +231,7 @@ void addLCBindings(lua_State *L) {
 	        cliCommand->write(message);
 	    })
 	    .addFunction("returnText", &widgets::CliCommand::returnText)
+	    .addFunction("commandActive", &widgets::CliCommand::commandActive)
 	);
 
 	state["lc"]["Toolbar"].setClass(kaguya::UserdataMetatable<widgets::Toolbar, QDockWidget>()

--- a/lcUI/widgets/clicommand.cpp
+++ b/lcUI/widgets/clicommand.cpp
@@ -91,7 +91,7 @@ void CliCommand::onReturnPressed() {
         }
         else {
             /* Check for command status and nested command like 'zoom or 'pan which can run in between some other active command.*/
-            if ((_commandActive) && (text.at(0) != "'")) {
+            if ((_commandActive) && (text.indexOf("'") != 0)) {
                 emit textEntered(text);
             }
             else {

--- a/lcUI/widgets/clicommand.cpp
+++ b/lcUI/widgets/clicommand.cpp
@@ -91,13 +91,12 @@ void CliCommand::onReturnPressed() {
         }
         else {
             /* Check for command status and nested command like 'zoom or 'pan which can run in between some other active command.*/
-            if ((_commandActive) && (text[0]!="'")) {
+            if ((_commandActive) && (text[0] != "'")) {
                 emit textEntered(text);
             }
             else {
                 enterCommand(text); 
             }
-
         }
     }
 

--- a/lcUI/widgets/clicommand.cpp
+++ b/lcUI/widgets/clicommand.cpp
@@ -91,7 +91,7 @@ void CliCommand::onReturnPressed() {
         }
         else {
             /* Check for command status and nested command like 'zoom or 'pan which can run in between some other active command.*/
-            if ((_commandActive) && (text[0] != "'")) {
+            if ((_commandActive) && (text.at(0) != "'")) {
                 emit textEntered(text);
             }
             else {

--- a/lcUI/widgets/clicommand.cpp
+++ b/lcUI/widgets/clicommand.cpp
@@ -15,6 +15,7 @@ CliCommand::CliCommand(QWidget* parent) :
     QDockWidget(parent),
     ui(new Ui::CliCommand),
     _returnText(false),
+    _commandActive(false),
     _historySize(10),
     _historyIndex(-1) {
     ui->setupUi(this);
@@ -89,7 +90,14 @@ void CliCommand::onReturnPressed() {
             }
         }
         else {
-            enterCommand(text);
+            /* Check for command status and nested command like 'zoom or 'pan which can run in between some other active command.*/
+            if ((_commandActive) && (text[0]!="'")) {
+                emit textEntered(text);
+            }
+            else {
+                enterCommand(text); 
+            }
+
         }
     }
 
@@ -197,4 +205,8 @@ void CliCommand::setText(const QString& text) {
 
 void CliCommand::returnText(bool returnText) {
     _returnText = returnText;
+}
+
+void CliCommand::commandActive(bool commandActive) {
+    _commandActive = commandActive;
 }

--- a/lcUI/widgets/clicommand.h
+++ b/lcUI/widgets/clicommand.h
@@ -58,6 +58,12 @@ namespace lc {
                      */
                     void returnText(bool returnText);
 
+                    /**
+                     * \brief Command is on or off.
+                     * \param commandActive true when command is on, false when command is over
+                     */
+                    void commandActive(bool commandActive);
+
                 public slots:
 
                     /**
@@ -99,6 +105,7 @@ namespace lc {
                     std::shared_ptr<QCompleter> _completer;
                     std::shared_ptr<QStringListModel> _commands;
                     bool _returnText;
+                    bool _commandActive;
 
                     QStringList _history;
                     int _historySize;

--- a/lcUILua/createActions/arcoperations.lua
+++ b/lcUILua/createActions/arcoperations.lua
@@ -10,60 +10,85 @@ setmetatable(ArcOperations, {
     end,
 })
 
-function ArcOperations:_init(widget)
-    CreateOperations._init(self, widget, lc.builder.ArcBuilder, "enterCenter")
+
+function ArcOperations:_init(id)
+    CreateOperations._init(self, id, lc.builder.ArcBuilder, "ArcWith3Points")
+    cli_get_text(self.target_widget, true)
     self.builder:setRadius(10)
-    self.builder:setStartAngle(0)
-    self.builder:setEndAngle(math.pi)
-
-    message("Click on center", widget)
+    Arc_FirstPoint = nil
+    Arc_SecondPoint = nil
+    Arc_ThirdPoint = nil
+    Arc_Center = nil
+    message("<b>Arc</b>", self.target_widget)
+    message("Options: <u>C</u>enter, or", self.target_widget)
+    message("Provide Start Point:", self.target_widget)
 end
 
-function ArcOperations:enterCenter(eventName, data)
-    if(eventName == "point" or eventName == "mouseMove") then
-        self.builder:setCenter(data["position"])
-    end
-
-    if(eventName == "point") then
-        message("Click on second point or enter the radius", self.target_widget)
-        self.step = "setRadius"
-    end
-end
-
-function ArcOperations:setRadius(eventName, data)
-    if(eventName == "point" or eventName == "mouseMove") then
-        self.builder:setRadius(Operations:getDistance(self.builder:center(), data["position"]))
-    elseif(eventName == "number") then
-        self.builder:setRadius(data["number"])
-    end
-
-    if(eventName == "point" or eventName == "number") then
-        message("Click on start point or enter the start angle", self.target_widget)
-        self.step = "setStartAngle"
-    end
-end
-
-function ArcOperations:setStartAngle(eventName, data)
-    if(eventName == "point" or eventName == "mouseMove") then
-        self.builder:setStartAngle(Operations:getAngle(self.builder:center(), data["position"]))
-    elseif(eventName == "number") then
-        self.builder:setStartAngle(data["number"])
-    end
-
-    if(eventName == "point" or eventName == "number") then
-        message("Click on end point or enter the end angle", self.target_widget)
-        self.step = "setEndAngle"
-    end
-end
-
-function ArcOperations:setEndAngle(eventName, data)
-    if(eventName == "point" or eventName == "mouseMove") then
+function ArcOperations:ArcWith3Points(eventName, data)
+    if(eventName == "text") then
+        if (string.lower(data["text"]) == "c" or string.lower(data["text"]) == "center") then
+            message("Provide Center Point:", self.target_widget)
+            self.step = "ArcWithCSE"
+        else
+            message("Invalid input:" .. data["text"] ,self.target_widget)
+            message("Provide Radius:", self.target_widget)
+        end
+    elseif (eventName == "point" and not Arc_FirstPoint) then
+        Arc_FirstPoint = data['position']
+        message("Provide Through Point:",self.target_widget)
+    elseif(eventName == "point" and Arc_FirstPoint and not Arc_SecondPoint) then
+        message("Provide End Point:",self.target_widget)
+        Arc_SecondPoint = data['position']
+    elseif(eventName == "mouseMove" and Arc_FirstPoint and Arc_SecondPoint and  not Arc_ThirdPoint) then
+        self.builder:setIsCCW(self:CheckCCW(Arc_FirstPoint,Arc_SecondPoint,data["position"]))
+        self.builder:setCenter(self:Circumcenter(Arc_FirstPoint,Arc_SecondPoint,data['position']))
+        self.builder:setRadius(self.builder:center():distanceTo(data['position']))
+        self.builder:setStartAngle(Operations:getAngle(self.builder:center(), Arc_FirstPoint))
         self.builder:setEndAngle(Operations:getAngle(self.builder:center(), data["position"]))
-    elseif(eventName == "number") then
-        self.builder:setEndAngle(data["number"])
-    end
 
-    if(eventName == "point" or eventName == "number") then
+    elseif(eventName == "point" and Arc_FirstPoint and Arc_SecondPoint and  not Arc_ThirdPoint) then
+        Arc_ThirdPoint = data['position']
+        self.builder:setIsCCW(self:CheckCCW(Arc_FirstPoint,Arc_SecondPoint,Arc_ThirdPoint))
+        self.builder:setCenter(self:Circumcenter(Arc_FirstPoint,Arc_SecondPoint,Arc_ThirdPoint))
+        self.builder:setRadius(self.builder:center():distanceTo(Arc_ThirdPoint))
+        self.builder:setStartAngle(Operations:getAngle(self.builder:center(), Arc_FirstPoint))
+        self.builder:setEndAngle(Operations:getAngle(self.builder:center(), data["position"]))
         self:createEntity()
     end
+end
+
+
+
+function ArcOperations:ArcWithCSE(eventName, data) -- Create Arc with Center Start and End Points.
+    if(eventName == "point" and not Arc_Center ) then
+        Arc_Center = data["position"]
+        self.builder:setCenter(data["position"])
+        message("Provide Start Point:", self.target_widget)
+    elseif(eventName == "point" and  Arc_Center and not Arc_FirstPoint ) then
+        Arc_FirstPoint = data["position"]
+        self.builder:setRadius(Operations:getDistance(self.builder:center(), data["position"]))
+        message("Provide End Point:", self.target_widget)
+    elseif(eventName == "mouseMove" and  Arc_Center and Arc_FirstPoint and not Arc_ThirdPoint) then
+        self.builder:setStartAngle(Operations:getAngle(self.builder:center(), Arc_FirstPoint))
+        self.builder:setEndAngle(Operations:getAngle(self.builder:center(), data["position"]))
+    elseif(eventName == "point" and  Arc_Center and Arc_FirstPoint and not Arc_ThirdPoint) then
+        self.builder:setStartAngle(Operations:getAngle(self.builder:center(), Arc_FirstPoint))
+        self.builder:setEndAngle(Operations:getAngle(self.builder:center(), data["position"]))
+        self:createEntity()
+    end
+end
+
+function ArcOperations:Circumcenter(Point1,Point2,Point3)
+    local Angle1=Point1:angleBetween(Point2,Point3)
+    local Angle2=Point2:angleBetween(Point3,Point1)
+    local Angle3=Point3:angleBetween(Point1,Point2)
+    local X = (Point1:x() * math.sin(2 * Angle1) + Point2:x() * math.sin(2 * Angle2) + Point3:x() * math.sin(2 * Angle3) ) / ( math.sin(2 * Angle1) + math.sin(2 * Angle2) + math.sin(2 * Angle3))
+    local Y = (Point1:y() * math.sin(2 * Angle1) + Point2:y() * math.sin(2 * Angle2) + Point3:y() * math.sin(2 * Angle3) ) / ( math.sin(2 * Angle1) + math.sin(2 * Angle2) + math.sin(2 * Angle3))
+    local Output=lc.geo.Coordinate(X,Y)
+    return Output
+end
+
+function ArcOperations:CheckCCW(P1,P2,P3)
+    local K = ((P2:y() - P1:y()) * ( P3:x() - P2:x() ) ) - ( (P2:x() - P1:x() ) * ( P3:y() - P2:y() ) )
+    if (K > 0) then return false else return true end
 end

--- a/lcUILua/createActions/arcoperations.lua
+++ b/lcUILua/createActions/arcoperations.lua
@@ -15,10 +15,10 @@ function ArcOperations:_init(id)
     CreateOperations._init(self, id, lc.builder.ArcBuilder, "ArcWith3Points")
     cli_get_text(self.target_widget, true)
     self.builder:setRadius(10)
-    Arc_FirstPoint = nil
-    Arc_SecondPoint = nil
-    Arc_ThirdPoint = nil
-    Arc_Center = nil
+    self.Arc_FirstPoint = nil
+    self.Arc_SecondPoint = nil
+    self.Arc_ThirdPoint = nil
+    self.Arc_Center = nil
     message("<b>Arc</b>", self.target_widget)
     message("Options: <u>C</u>enter, or", self.target_widget)
     message("Provide Start Point:", self.target_widget)

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -12,13 +12,15 @@ setmetatable(CircleOperations, {
 
 function CircleOperations:_init(id)
     CreateOperations._init(self, id, lc.builder.CircleBuilder, "enterCenter")
-    cli_get_text(self.target_widget, true) -- This command prevents the user from entering coordinates in the command line. But at the same time it is needed for receiving text options from user. Alternate method need to be worked out.
+    --cli_get_text(self.target_widget, true) -- This command prevents the user from entering coordinates in the command line. But at the same time it is needed for receiving text options from user. Alternate method need to be worked out.
+    cli_command_active(self.target_widget, true)
+
     self.builder:setRadius(10)
     self.firstpoint = nil
     self.secondpoint = nil
     self.thirdpoint = nil
     message("<b>CIRCLE</b>", self.target_widget)
-    message("Options: <b><u>2</u>P</b>, <u>3</u>P, <u>T</u>TT, TT<u>R</u>", self.target_widget)
+    message("Options: <b><u>2P</u>oint</b>, <u>3P</u>oint, <u>T</u>TT, TT<u>R</u>", self.target_widget)
     message("Provide Center Point:", self.target_widget)
 end
 
@@ -64,10 +66,10 @@ function CircleOperations:enterCenter(eventName, data)
         message("Provide Radius:", self.target_widget)
         self.step = "enterRadius"
     elseif(eventName == "text") then
-        if ((data["text"]) == "2" or string.lower(data["text"]) == "2p") then
+        if ((data["text"]) == "2p" or string.lower(data["text"]) == "2point") then
             message("Provide Diameter Start Point:",self.target_widget)
             self.step = "CircleWith2Points"
-        elseif ((data["text"]) == "3" or string.lower(data["text"]) == "3p") then
+        elseif ((data["text"]) == "3p" or string.lower(data["text"]) == "3point") then
             message("Provide Frist Point:",self.target_widget)
             self.step = "CircleWith3Points"
         elseif (string.lower(data["text"]) == "t" or string.lower(data["text"]) == "ttt") then

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -18,8 +18,43 @@ function CircleOperations:_init(id)
     self.secondpoint = nil
     self.thirdpoint = nil
     message("<b>CIRCLE</b>", self.target_widget)
-    message("Options: <u>2</u>P, <u>3</u>P, <u>T</u>TT, TT<u>R</u>", self.target_widget)
+    message("Options: <b><u>2</u>P</b>, <u>3</u>P, <u>T</u>TT, TT<u>R</u>", self.target_widget)
     message("Provide Center Point:", self.target_widget)
+end
+
+
+function CircleOperations:_init_cr()
+    message("<b>CIRCLE</b>", self.target_widget)
+    message("Provide Center Point:", self.target_widget)
+    self.step = "CircleWithCenterRadius"
+end
+
+function CircleOperations:_init_cd()
+    message("<b>CIRCLE</b>", self.target_widget)
+    message("Provide Center Point:", self.target_widget)
+    self.step = "CircleWithCenterDiameter"
+end
+
+function CircleOperations:_init_2p()
+    message("<b>CIRCLE</b>", self.target_widget)
+    message("Provide First Point:", self.target_widget)
+    self.step = "CircleWith2Points"
+end
+
+function CircleOperations:_init_3p()
+    message("<b>CIRCLE</b>", self.target_widget)
+    message("Provide First Point:", self.target_widget) 
+    self.step = "CircleWith3Points"
+end
+
+function CircleOperations:_init_3t()
+    message("<b>CIRCLE</b>", self.target_widget)
+    self.step = "CircleWith3Tans"
+end
+
+function CircleOperations:_init_2t()
+    message("<b>CIRCLE</b>", self.target_widget)
+    self.step = "CircleWith2Tans"
 end
 
 function CircleOperations:enterCenter(eventName, data)
@@ -33,13 +68,13 @@ function CircleOperations:enterCenter(eventName, data)
             message("Provide Diameter Start Point:",self.target_widget)
             self.step = "CircleWith2Points"
         elseif ((data["text"]) == "3" or string.lower(data["text"]) == "3p") then
-            message("Provide First Point:",self.target_widget)
+            message("Provide Frist Point:",self.target_widget)
             self.step = "CircleWith3Points"
         elseif (string.lower(data["text"]) == "t" or string.lower(data["text"]) == "ttt") then
-            message("Provide First Tangent:",self.target_widget)
+            message("Provide Frist Tangent:",self.target_widget)
             self.step = "CircleWith3Tans"
         elseif (string.lower(data["text"]) == "r" or string.lower(data["text"]) == "ttr") then
-            message("Provide First Tangent:",self.target_widget)
+            message("Provide Frist Tangent:",self.target_widget)
             self.step = "CircleWith2Tans"
         end
     end
@@ -87,9 +122,42 @@ function CircleOperations:enterDiameter(eventName, data)
     end
 end
 
+function CircleOperations:CircleWithCenterRadius(eventName, data)
+    if (eventName == "point" and not self.centerPoint) then
+        self.centerPoint=data["position"]
+        self.builder:setCenter(data["position"])
+        message("Provide Radius:", self.target_widget)
+    elseif (eventName == "mouseMove" and self.centerPoint) then
+        self.builder:setRadius(self.builder:center():distanceTo(data["position"]))
+    elseif (eventName == "point" and self.centerPoint) then
+        self.builder:setRadius(self.builder:center():distanceTo(data["position"]))
+        self:createEntity()
+    elseif (eventName == "number" and self.centerPoint) then
+        self.builder:setRadius(data["number"])
+        self:createEntity()
+    end
+end
+
+function CircleOperations:CircleWithCenterDiameter(eventName, data)
+    if (eventName == "point" and not self.centerPoint) then
+        self.centerPoint=data["position"]
+        self.builder:setCenter(data["position"])
+        message("Provide Diameter:", self.target_widget)
+    elseif (eventName == "mouseMove" and self.centerPoint) then
+        self.builder:setRadius(self.builder:center():distanceTo(data["position"])/2)
+    elseif (eventName == "point" and self.centerPoint) then
+        self.builder:setRadius(self.builder:center():distanceTo(data["position"])/2)
+        self:createEntity()
+    elseif (eventName == "number" and self.centerPoint) then
+        self.builder:setRadius(data["number"]/2)
+        self:createEntity()
+    end
+end
+
 function CircleOperations:CircleWith2Points(eventName, data)
     if (eventName == "point" and not self.firstpoint) then
         self.firstpoint = data['position']
+        message("Provide Second Point:", self.target_widget)
     elseif (eventName == "mouseMove" and self.firstpoint) then
         self.builder:setCenter(self.firstpoint:mid(data["position"]))
         self.builder:setRadius(self.firstpoint:distanceTo(data["position"]) / 2)
@@ -97,7 +165,6 @@ function CircleOperations:CircleWith2Points(eventName, data)
         self.builder:setCenter(self.firstpoint:mid(data["position"]))
         self.builder:setRadius(self.firstpoint:distanceTo(data["position"]) / 2)
         self:createEntity()
-        self.firstpoint = nil
     end
 end
 
@@ -120,11 +187,13 @@ function CircleOperations:CircleWith3Points(eventName, data)
 end
 
 function CircleOperations:CircleWith3Tans(eventName, data)
-    message("TODO:3 Tan Circle.",self.target_widget) -- This function requires picking or selecting CIRCLE or ARC entities. Once picking or selecting of objects starts working this function can be coded.
+    message("TODO:3 Tan Circle.",self.target_widget) -- This function requires picking or selecting CIRCLE or ARC entities. Once picking or selcting of objects starts working this function can be coded.
+    finish_operation(self.target_widget)
 end
 
 function CircleOperations:CircleWith2Tans(eventName, data)
-    message("TODO:2 Tan Circle.",self.target_widget) -- This function requires picking or selecting CIRCLE or ARC entities. Once picking or selecting of objects starts working this function can be coded.
+    message("TODO:2 Tan Circle.",self.target_widget) -- This function requires picking or selecting CIRCLE or ARC entities. Once picking or selcting of objects starts working this function can be coded.
+    finish_operation(self.target_widget)
 end
 
 function CircleOperations:Circumcenter(Point1,Point2,Point3)

--- a/lcUILua/createActions/ellipseoperations.lua
+++ b/lcUILua/createActions/ellipseoperations.lua
@@ -10,6 +10,109 @@ setmetatable(EllipseOperations, {
     end,
 })
 
+
+function EllipseOperations:_init(id, isArc)
+    self.isArc = isArc or false
+    self.Axis_StartPoint = nil
+    self.Axis_EndPoint = nil
+    self.Axis_CenterPoint = nil
+    self.rotation = false
+    CreateOperations._init(self, id, lc.builder.EllipseBuilder, "EllipsewithAxisEnd")
+    cli_get_text(self.target_widget, true) -- This command prevents the user from entering coordinates in the command line. But at the same time it is needed for receiving text options from user. Alternate method need to be worked out.
+
+    message("<b>Ellipse</b>", self.target_widget)
+    message("Options: <u>E</u>lliptical Arc, <u>C</u>enter", self.target_widget)
+    message("Provide Axis start Point:", self.target_widget)
+end
+
+function EllipseOperations:EllipsewithAxisEnd(eventName, data)
+    if(eventName == "text" and not self.Axis_StartPoint) then
+        if (string.lower(data["text"]) == "c" or string.lower(data["text"]) == "center") then
+            message("Provide Center Point:", self.target_widget)
+            cli_get_text(self.target_widget, false)
+            self.step = "EllipsewithCenter"
+        else
+            message("Invalid input:" .. data["text"] ,self.target_widget)
+            message("Provide Axis start Point:", self.target_widget)
+        end
+    elseif (eventName == "point" and not self.Axis_StartPoint ) then
+        self.Axis_StartPoint = data['position']
+        message("Provide Axis end Point:",self.target_widget)
+    elseif (eventName == "point" and self.Axis_StartPoint and not self.Axis_EndPoint) then
+        self.Axis_EndPoint = data['position']
+        self.builder:setCenter(self.Axis_StartPoint:mid(self.Axis_EndPoint))
+        self.builder:setMajorPoint(self.Axis_EndPoint:sub(self.builder:center()))
+        message("Options: <u>R</u>otation or",self.target_widget)
+        message("Provide other axis end Point:",self.target_widget)
+    elseif (eventName == "text" and self.Axis_StartPoint and self.Axis_EndPoint) then
+        if (string.lower(data["text"]) == "r" or string.lower(data["text"]) == "rotation") then
+            message("Specify rotation:", self.target_widget)
+            self.rotation = true
+            cli_get_text(self.target_widget, false)
+        else
+            message("Invalid input:" .. data["text"] ,self.target_widget)
+            message("Provide other axis end Point:", self.target_widget)
+        end
+    elseif (eventName == "mouseMove" and self.Axis_StartPoint and self.Axis_EndPoint and self.rotation == false) then
+        self.builder:setMinorRadius(self.builder:center():distanceTo(data["position"]))
+    elseif (eventName == "point" and self.Axis_StartPoint and self.Axis_EndPoint and self.rotation == false) then
+        self.builder:setMinorRadius(self.builder:center():distanceTo(data["position"]))
+        self:createEntity()
+    elseif (eventName == "mouseMove" and self.Axis_StartPoint and self.Axis_EndPoint and self.rotation == true) then
+        self.builder:setMinorRadius ( math.cos(self.builder:center():angleTo(data["position"])) *  self.Axis_StartPoint:distanceTo(self.Axis_EndPoint) / 2)
+    elseif (eventName == "point" and self.Axis_StartPoint and self.Axis_EndPoint and self.rotation == true) then
+        self.builder:setMinorRadius ( math.cos(self.builder:center():angleTo(data["position"])) *  self.Axis_StartPoint:distanceTo(self.Axis_EndPoint) / 2)
+        self:createEntity()
+    elseif (eventName == "number" and self.Axis_StartPoint and self.Axis_EndPoint and self.rotation == true) then
+        local angle = math.rad(data["number"])
+        self.builder:setMinorRadius ( math.cos(angle) *  self.Axis_StartPoint:distanceTo(self.Axis_EndPoint) / 2)
+        self:createEntity()
+    end
+end
+
+function EllipseOperations:EllipsewithCenter(eventName, data)
+    if (eventName == "point" and not self.Axis_CenterPoint ) then
+        self.Axis_CenterPoint = data['position']
+        self.builder:setCenter(self.Axis_CenterPoint)
+        message("Provide Axis end Point:",self.target_widget)
+    elseif (eventName == "point" and self.Axis_CenterPoint and not self.Axis_EndPoint) then
+        self.Axis_EndPoint = data['position']
+        self.builder:setMajorPoint(self.Axis_EndPoint:sub(self.builder:center()))
+        message("Options: <u>R</u>otation or",self.target_widget)
+        cli_get_text(self.target_widget, true)
+        message("Provide other axis end Point:",self.target_widget)
+    elseif (eventName == "text" and self.Axis_EndPoint) then
+        if (string.lower(data["text"]) == "r" or string.lower(data["text"]) == "rotation") then
+            message("Specify rotation:", self.target_widget)
+            self.rotation = true
+            cli_get_text(self.target_widget, false)
+        else
+            message("Invalid input:" .. data["text"] ,self.target_widget)
+            message("Provide other axis end Point:", self.target_widget)
+        end
+    elseif (eventName == "mouseMove"  and self.Axis_EndPoint and self.rotation == false) then
+        self.minRadius=self.builder:center():distanceTo(data["position"])
+        self.builder:setMinorRadius(self.minRadius)
+    elseif (eventName == "point" and self.Axis_EndPoint and self.rotation == false) then
+        self.minRadius=self.builder:center():distanceTo(data["position"])
+        self.builder:setMinorRadius(self.minRadius)
+        self:createEntity()
+    elseif (eventName == "mouseMove"  and self.Axis_EndPoint and self.rotation == true) then
+        self.minRadius = math.cos(self.builder:center():angleTo(data["position"])) *  self.Axis_CenterPoint:distanceTo(self.Axis_EndPoint)
+        self.builder:setMinorRadius (self.minRadius )
+    elseif (eventName == "point" and self.Axis_EndPoint and self.rotation == true ) then
+        self.minRadius = math.cos(self.builder:center():angleTo(data["position"])) *  self.Axis_CenterPoint:distanceTo(self.Axis_EndPoint)
+        self.builder:setMinorRadius (self.minRadius )
+        self:createEntity()
+    elseif (eventName == "number" and self.Axis_EndPoint and self.rotation == true) then
+        self.minRadius =  math.cos(math.rad(data["number"])) *  self.Axis_CenterPoint:distanceTo(self.Axis_EndPoint)
+        self.builder:setMinorRadius(self.minRadius)
+        self:createEntity()
+    end
+end
+
+
+--[[
 function EllipseOperations:_init(id, isArc)
     self.isArc = isArc or false
 
@@ -22,6 +125,8 @@ function EllipseOperations:_init(id, isArc)
 
     message("Click on center", id)
 end
+]]
+
 
 function EllipseOperations:setCenter(eventName, data)
     if(eventName == "point" or eventName == "mouseMove") then

--- a/lcUILua/createActions/lineoperations.lua
+++ b/lcUILua/createActions/lineoperations.lua
@@ -12,17 +12,16 @@ setmetatable(LineOperations, {
 
 function LineOperations:_init(id)
     CreateOperations._init(self, id, lc.builder.LineBuilder, "setFirstPoint")
-
     self.length = nil
-
-    message("Click on first point", id)
+    message("<b>LINE</b>", self.target_widget)
+    --message("Options: <b><u>C</u>ontinuous</b>, <u>S</u>egment", self.target_widget)  TODO: Multiple lines in single command.
+    message("Click on first point or enter coordinates:", self.target_widget)
 end
 
 function LineOperations:setFirstPoint(eventName, data)
     if(eventName == "point") then
         self.builder:setStartPoint(data["position"])
-        message("Click on second point or enter line length", self.target_widget)
-
+        message("Click on second point or enter coordinates or enter line length", self.target_widget)
         self.step = "setSecondPoint"
     end
 end
@@ -51,9 +50,10 @@ function LineOperations:setSecondPoint(eventName, data)
             local relativeCoordinate = lc.geo.Coordinate(angle):multiply(self.length)
             self.builder:setEndPoint(self.builder:startPoint():add(relativeCoordinate))
             self:createEntity()
+
         else
             self.length = data["number"]
-            message("Click on second point or enter line angle", self.target_widget)
+            message("Click on second point or enter coordinates or enter line angle", self.target_widget)
         end
     end
 end

--- a/lcUILua/createActions/lineoperations.lua
+++ b/lcUILua/createActions/lineoperations.lua
@@ -50,7 +50,6 @@ function LineOperations:setSecondPoint(eventName, data)
             local relativeCoordinate = lc.geo.Coordinate(angle):multiply(self.length)
             self.builder:setEndPoint(self.builder:startPoint():add(relativeCoordinate))
             self:createEntity()
-
         else
             self.length = data["number"]
             message("Click on second point or enter coordinates or enter line angle", self.target_widget)

--- a/lcUILua/ui/commandline.lua
+++ b/lcUILua/ui/commandline.lua
@@ -21,6 +21,13 @@ function add_command(name, callback)
     end
 end
 
+--Coomand line command On/OFF
+function cli_command_active(id, status)
+    if cliCommands[id] ~= nil then
+        cliCommands[id]:commandActive(status)
+    end
+end
+
 --Configure command line to return raw text
 function cli_get_text(id, getText)
     if cliCommands[id] ~= nil then


### PR DESCRIPTION
By adding cli_get_text(self.target_widget, true) we use to return raw text. But at the same time points, coordinates, numbers were not available. Due to this none of commands like circle, line were able to function correctly.
The workaround in the PR is cli_command_active(self.target_widget, true) which sets _commandActive to true. If this variable is true then any input text which is not point coordinate or number is returned as raw text option.
Additional check for command starting with " ' " will make it possible in future to give nested commands like 'zoom 'pan