### PR TITLE
Get correct layers when loading a DXF file

### DIFF
--- a/persistence/libdxfrw/dxfimpl.cpp
+++ b/persistence/libdxfrw/dxfimpl.cpp
@@ -245,8 +245,7 @@ void DXFimpl::addLayer(const DRW_Layer& data) {
         _builder->append(al);
     }
     else if (data.name.length() > 0 && (data.name.compare(0,1,"*") != 0)) {
-        auto al = std::make_shared<lc::operation::AddLayer>(_document, layer);
-        _builder->append(al);
+        std::make_shared<lc::operation::AddLayer>(_document, layer)->execute();
     }
 }
 


### PR DESCRIPTION
Layer from DXF files were added to Document after inserting entities.
`layerByName` was returning a default layer then.