### PR TITLE
Connected buttons under Create and Draw menu

### DIFF
--- a/lcUI/ui/mainwindow.ui
+++ b/lcUI/ui/mainwindow.ui
@@ -83,7 +83,6 @@
       <string>&amp;Line</string>
      </property>
      <addaction name="action2_Point_Line"/>
-     <addaction name="actionConstruction_Line"/>
     </widget>
     <widget class="QMenu" name="menuCircle">
      <property name="title">

--- a/lcUILua/createActions/arcoperations.lua
+++ b/lcUILua/createActions/arcoperations.lua
@@ -19,8 +19,16 @@ function ArcOperations:_init(id)
     self.Arc_SecondPoint = nil
     self.Arc_ThirdPoint = nil
     self.Arc_Center = nil
+end
+
+function ArcOperations:_init_default()
     message("<b>Arc</b>", self.target_widget)
     message("Options: <u>C</u>enter, or", self.target_widget)
+    message("Provide Start Point:", self.target_widget)
+end
+
+function ArcOperations:_init_3p()
+    message("<b>Arc 3 point</b>", self.target_widget)
     message("Provide Start Point:", self.target_widget)
 end
 

--- a/lcUILua/createActions/arcoperations.lua
+++ b/lcUILua/createActions/arcoperations.lua
@@ -25,11 +25,19 @@ function ArcOperations:_init_default()
     message("<b>Arc</b>", self.target_widget)
     message("Options: <u>C</u>enter, or", self.target_widget)
     message("Provide Start Point:", self.target_widget)
+	self.step = "ArcWith3Points"
 end
 
 function ArcOperations:_init_3p()
     message("<b>Arc 3 point</b>", self.target_widget)
     message("Provide Start Point:", self.target_widget)
+	self.step = "ArcWith3Points"
+end
+
+function ArcOperations:_init_cse()
+    message("<b>Arc 3 point</b>", self.target_widget)
+    message("Provide Center Point:", self.target_widget)
+	self.step = "ArcWithCSE"
 end
 
 function ArcOperations:ArcWith3Points(eventName, data)

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -26,6 +26,7 @@ function CircleOperations:_init_default()
 	message("<b>CIRCLE</b>", self.target_widget)
     message("Options: <b><u>2P</u>oint</b>, <u>3P</u>oint, <u>T</u>TT, TT<u>R</u>", self.target_widget)
     message("Provide Center Point:", self.target_widget)
+	self.step = "CircleWithCenterRadius"
 end
 
 function CircleOperations:_init_cr()

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -19,11 +19,14 @@ function CircleOperations:_init(id)
     self.firstpoint = nil
     self.secondpoint = nil
     self.thirdpoint = nil
-    message("<b>CIRCLE</b>", self.target_widget)
+end
+
+--test
+function CircleOperations:_init_default()
+	message("<b>CIRCLE</b>", self.target_widget)
     message("Options: <b><u>2P</u>oint</b>, <u>3P</u>oint, <u>T</u>TT, TT<u>R</u>", self.target_widget)
     message("Provide Center Point:", self.target_widget)
 end
-
 
 function CircleOperations:_init_cr()
     message("<b>CIRCLE</b>", self.target_widget)

--- a/lcUILua/ui/mainwindow.lua
+++ b/lcUILua/ui/mainwindow.lua
@@ -125,8 +125,8 @@ local function create_menu(mainWindow, widget, commandLine, id)
 
 	-- connect draw menu options
 	luaInterface:luaConnect(lineAction, "triggered(bool)", function() run_basic_operation(id, LineOperations) end)
-	luaInterface:luaConnect(circleAction, "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
-	luaInterface:luaConnect(arcAction, "triggered(bool)", function() run_basic_operation(id, ArcOperations) end)
+	luaInterface:luaConnect(circleAction, "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_default()  end)
+	luaInterface:luaConnect(arcAction, "triggered(bool)", function() op = run_basic_operation(id, ArcOperations); op:_init_3p() end)
 	luaInterface:luaConnect(ellipseAction, "triggered(bool)", function() run_basic_operation(id, EllipseOperations) end)
 	luaInterface:luaConnect(splineAction, "triggered(bool)", function() run_basic_operation(id, SplineOperations) end)
 	luaInterface:luaConnect(polylineAction, "triggered(bool)", function() create_lw_polyline(id) end)
@@ -138,11 +138,15 @@ local function connect_buttons(mainWindow, id)
 	luaInterface:luaConnect(mainWindow:findChild("action2_Point_Line"), "triggered(bool)", function() run_basic_operation(id, LineOperations) end)
 	
 	-- circle
-	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Radius"), "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
-	--luaInterface:luaConnect(mainWindow:findChild("actionCenter_Diameter"), "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Radius"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_cr()  end)
+	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Diameter"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_cd() end)
+	luaInterface:luaConnect(mainWindow:findChild("action2_Point_Circle"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_2p() end)
+	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Circle_2"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_3p() end)
+	luaInterface:luaConnect(mainWindow:findChild("actionTan_Tan_Radius"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_3t() end)
+	luaInterface:luaConnect(mainWindow:findChild("actionTan_Tan_Tan"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_2t() end)
 
 	-- arc
-	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Arc"), "triggered(bool)", function() run_basic_operation(id, ArcOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Arc"), "triggered(bool)", function() op = run_basic_operation(id, ArcOperations); op:_init_3p() end)
 
 	-- ellipse
 	luaInterface:luaConnect(mainWindow:findChild("actionEllipse"), "triggered(bool)", function() run_basic_operation(id, EllipseOperations) end)

--- a/lcUILua/ui/mainwindow.lua
+++ b/lcUILua/ui/mainwindow.lua
@@ -147,6 +147,7 @@ local function connect_buttons(mainWindow, id)
 
 	-- arc
 	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Arc"), "triggered(bool)", function() op = run_basic_operation(id, ArcOperations); op:_init_3p() end)
+	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Start_End_2"), "triggered(bool)", function() op = run_basic_operation(id, ArcOperations); op:_init_cse() end)
 
 	-- ellipse
 	luaInterface:luaConnect(mainWindow:findChild("actionEllipse"), "triggered(bool)", function() run_basic_operation(id, EllipseOperations) end)

--- a/lcUILua/ui/mainwindow.lua
+++ b/lcUILua/ui/mainwindow.lua
@@ -139,6 +139,7 @@ local function connect_buttons(mainWindow, id)
 	
 	-- circle
 	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Radius"), "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
+	--luaInterface:luaConnect(mainWindow:findChild("actionCenter_Diameter"), "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
 
 	-- arc
 	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Arc"), "triggered(bool)", function() run_basic_operation(id, ArcOperations) end)
@@ -151,6 +152,13 @@ local function connect_buttons(mainWindow, id)
 
 	-- polylines
 	luaInterface:luaConnect(mainWindow:findChild("actionPolyline"), "triggered(bool)", function() create_lw_polyline(id) end)
+
+	--dimensions
+	luaInterface:luaConnect(mainWindow:findChild("actionLinear"), "triggered(bool)", function() run_basic_operation(id, DimLinearOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("actionAligned"), "triggered(bool)", function() run_basic_operation(id, DimAlignedOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("actionRadius"), "triggered(bool)", function() run_basic_operation(id, DimRadialOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("actionDiameter"), "triggered(bool)", function() run_basic_operation(id, DimDiametricOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("actionANG3PT"), "triggered(bool)", function() run_basic_operation(id, DimAngularOperations) end)
 end
 
 --Create a new window

--- a/lcUILua/ui/mainwindow.lua
+++ b/lcUILua/ui/mainwindow.lua
@@ -84,12 +84,15 @@ local  function changelcTolerance(id)
 end
 
 --Create main window menu
-local function create_menu(mainWindow, widget, commandLine)
+local function create_menu(mainWindow, widget, commandLine, id)
     local menuBar = mainWindow:menuBar()
     local drawMenu = menuBar:addMenuStr(qt.QString("Draw"))
     local lineAction = drawMenu:addActionStr(qt.QString("Line"))
     local circleAction = drawMenu:addActionStr(qt.QString("Circle"))
     local arcAction = drawMenu:addActionStr(qt.QString("Arc"))
+	local ellipseAction = drawMenu:addActionStr(qt.QString("Ellipse"))
+	local splineAction = drawMenu:addActionStr(qt.QString("Spline"))
+	local polylineAction = drawMenu:addActionStr(qt.QString("Polyline"))
 
     local luaMenu = menuBar:addMenuStr(qt.QString("Lua"))
     local luaScriptAction = luaMenu:addActionStr(qt.QString("Run script"))
@@ -119,6 +122,35 @@ local function create_menu(mainWindow, widget, commandLine)
         open_lua_script(widget, commandLine)
     end)
     luaInterface:luaConnect(lcTolerance, "triggered(bool)", changelcTolerance)
+
+	-- connect draw menu options
+	luaInterface:luaConnect(lineAction, "triggered(bool)", function() run_basic_operation(id, LineOperations) end)
+	luaInterface:luaConnect(circleAction, "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
+	luaInterface:luaConnect(arcAction, "triggered(bool)", function() run_basic_operation(id, ArcOperations) end)
+	luaInterface:luaConnect(ellipseAction, "triggered(bool)", function() run_basic_operation(id, EllipseOperations) end)
+	luaInterface:luaConnect(splineAction, "triggered(bool)", function() run_basic_operation(id, SplineOperations) end)
+	luaInterface:luaConnect(polylineAction, "triggered(bool)", function() create_lw_polyline(id) end)
+end
+
+-- Connect menu buttons in the menu bar
+local function connect_buttons(mainWindow, id)
+	-- line
+	luaInterface:luaConnect(mainWindow:findChild("action2_Point_Line"), "triggered(bool)", function() run_basic_operation(id, LineOperations) end)
+	
+	-- circle
+	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Radius"), "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
+
+	-- arc
+	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Arc"), "triggered(bool)", function() run_basic_operation(id, ArcOperations) end)
+
+	-- ellipse
+	luaInterface:luaConnect(mainWindow:findChild("actionEllipse"), "triggered(bool)", function() run_basic_operation(id, EllipseOperations) end)
+
+	-- spline
+	luaInterface:luaConnect(mainWindow:findChild("actionSpline"), "triggered(bool)", function() run_basic_operation(id, SplineOperations) end)
+
+	-- polylines
+	luaInterface:luaConnect(mainWindow:findChild("actionPolyline"), "triggered(bool)", function() create_lw_polyline(id) end)
 end
 
 --Create a new window
@@ -147,7 +179,8 @@ function create_new_window(widget)
     add_toolbar(mainWindow, id, linePatternSelect, lineWidthSelect, colorSelect)
     addCadMdiChild(widget, id, commandLine)
 
-    create_menu(mainWindow, widget, commandLine)
+    create_menu(mainWindow, widget, commandLine, id)
+	connect_buttons(mainWindow, id)
 
     if(hideUI ~= true) then
         mainWindow:showMaximized()

--- a/lcUILua/ui/operations.lua
+++ b/lcUILua/ui/operations.lua
@@ -38,6 +38,8 @@ function run_basic_operation(id, operation, ...)
     finish_operation(id)
     create_cancel_button(id)
     luaInterface:setOperation(id, operation(id, ...))
+	op = luaInterface:operation(id)
+	return op
 end
 
 function create_lw_polyline(id)


### PR DESCRIPTION
Made the following changes in this PR -

1) Added connect calls to the mainwindow.lua file to run appropriate actions on clicking their respective buttons in the create and draw menu.

2) Added Ellipse, Spline and Polyline to draw menu.

3) Changed operations.lua to return a lua reference, so that functions can be called by the calling function.

4) Refactored circleoperations.lua and arcoperations.lua so that _init function only contains initialization. 

5) Options under draw menu call the init_default whereas those under the create menu call their respective init methods.