### PR TITLE
Fixed LWPolyline and Connected buttons under Create and Draw menu

### DIFF
--- a/lcUI/ui/mainwindow.ui
+++ b/lcUI/ui/mainwindow.ui
@@ -83,7 +83,6 @@
       <string>&amp;Line</string>
      </property>
      <addaction name="action2_Point_Line"/>
-     <addaction name="actionConstruction_Line"/>
     </widget>
     <widget class="QMenu" name="menuCircle">
      <property name="title">

--- a/lcUILua/createActions/arcoperations.lua
+++ b/lcUILua/createActions/arcoperations.lua
@@ -19,8 +19,16 @@ function ArcOperations:_init(id)
     self.Arc_SecondPoint = nil
     self.Arc_ThirdPoint = nil
     self.Arc_Center = nil
+end
+
+function ArcOperations:_init_default()
     message("<b>Arc</b>", self.target_widget)
     message("Options: <u>C</u>enter, or", self.target_widget)
+    message("Provide Start Point:", self.target_widget)
+end
+
+function ArcOperations:_init_3p()
+    message("<b>Arc 3 point</b>", self.target_widget)
     message("Provide Start Point:", self.target_widget)
 end
 

--- a/lcUILua/createActions/arcoperations.lua
+++ b/lcUILua/createActions/arcoperations.lua
@@ -25,11 +25,19 @@ function ArcOperations:_init_default()
     message("<b>Arc</b>", self.target_widget)
     message("Options: <u>C</u>enter, or", self.target_widget)
     message("Provide Start Point:", self.target_widget)
+	self.step = "ArcWith3Points"
 end
 
 function ArcOperations:_init_3p()
     message("<b>Arc 3 point</b>", self.target_widget)
     message("Provide Start Point:", self.target_widget)
+	self.step = "ArcWith3Points"
+end
+
+function ArcOperations:_init_cse()
+    message("<b>Arc 3 point</b>", self.target_widget)
+    message("Provide Center Point:", self.target_widget)
+	self.step = "ArcWithCSE"
 end
 
 function ArcOperations:ArcWith3Points(eventName, data)

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -26,6 +26,7 @@ function CircleOperations:_init_default()
 	message("<b>CIRCLE</b>", self.target_widget)
     message("Options: <b><u>2P</u>oint</b>, <u>3P</u>oint, <u>T</u>TT, TT<u>R</u>", self.target_widget)
     message("Provide Center Point:", self.target_widget)
+	self.step = "CircleWithCenterRadius"
 end
 
 function CircleOperations:_init_cr()

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -19,11 +19,14 @@ function CircleOperations:_init(id)
     self.firstpoint = nil
     self.secondpoint = nil
     self.thirdpoint = nil
-    message("<b>CIRCLE</b>", self.target_widget)
+end
+
+--test
+function CircleOperations:_init_default()
+	message("<b>CIRCLE</b>", self.target_widget)
     message("Options: <b><u>2P</u>oint</b>, <u>3P</u>oint, <u>T</u>TT, TT<u>R</u>", self.target_widget)
     message("Provide Center Point:", self.target_widget)
 end
-
 
 function CircleOperations:_init_cr()
     message("<b>CIRCLE</b>", self.target_widget)

--- a/lcUILua/createActions/lwpolylineoperations.lua
+++ b/lcUILua/createActions/lwpolylineoperations.lua
@@ -17,23 +17,29 @@ function LWPolylineOperations:_init(id)
 end
 
 function LWPolylineOperations:enterPoint(eventName, data)
-	if(eventName == "point" or eventName == "number") then
+	
+	if(self.tempPoint) then
+		self.builder:removeVertex(-1)
+		self.tempPoint = false
+	end
+
+	if(eventName == "mouseMove") then
         self:newData(data["position"])
-    elseif(eventName == "mouseMove") then
-		self:refreshTempEntity()
+		self.tempPoint = true
+	elseif(eventName == "point" or eventName == "number") then
+        self:newData(data["position"])
     end
 end
 
 function LWPolylineOperations:newData(data)
-    local point = Operations:getCoordinate(data)
-    if(point ~= nil) then
+    if(data ~= nil) then
         if(self.currentVertex == "line") then
 			self.builder:addLineVertex(data)
         elseif(self.currentVertex == "arc") then
 			self.builder:addArcVertex(data)
         end
     else
-		self.build:modifyLastVertex(data)
+		self.builder:modifyLastVertex(data)
     end
 end
 
@@ -44,6 +50,11 @@ function LWPolylineOperations:refreshTempEntity()
 end
 
 function LWPolylineOperations:close()
+    if(self.tempPoint) then
+            self.builder:removeVertex(-1)
+            self.tempPoint = false
+    end
+
 	if(self.creatingPolyspline == nil) then
         self.creatingPolyspline = true
         self:createEntity()

--- a/lcUILua/createActions/lwpolylineoperations.lua
+++ b/lcUILua/createActions/lwpolylineoperations.lua
@@ -11,121 +11,53 @@ setmetatable(LWPolylineOperations, {
 })
 
 function LWPolylineOperations:_init(id)
-    --self.currentVertex_Bulge = 1
-    --self.currentVertex_StartWidth = 0
-    --self.currentVertex_EndWidth = 0
-
-    --self.lwVertexes = {}
-
     CreateOperations._init(self, id, lc.builder.LWPolylineBuilder, "enterPoint")
+	self.currentVertex = "line"
+	self.tempPoint = false
 end
 
 function LWPolylineOperations:enterPoint(eventName, data)
 	if(eventName == "point" or eventName == "number") then
         self:newData(data["position"])
     elseif(eventName == "mouseMove") then
-        --self:createTempLWPolyline(data["position"])
-		self.builder:createTempLWPolyline(data["position"])
-		self:build()
+		--self.builder:createTempLWPolyline(data["position"])
+		self:refreshTempEntity()
     end
 end
-
---[[function LWPolylineOperations:onEvent(eventName, data)
-    if(Operations.forMe(self, data) == false) then
-        return
-    end
-
-    if(eventName == "point" or eventName == "number") then
-        self:newData(data["position"])
-    elseif(eventName == "mouseMove") then
-        self:createTempLWPolyline(data["position"])
-    end
-end ]]--
 
 function LWPolylineOperations:newData(data)
     local point = Operations:getCoordinate(data)
     if(point ~= nil) then
         if(self.currentVertex == "line") then
-            --table.insert(self.lwVertexes, LWVertex2D(data))
 			self.builder:addLineVertex(data)
         elseif(self.currentVertex == "arc") then
-            --table.insert(self.lwVertexes, LWVertex2D(data, self.currentVertex_Bulge))
 			self.builder:addArcVertex(data)
         end
     else
-		-- # means length of table
-        --local vertex = self.lwVertexes[#self.lwVertexes]
-        
-        --self.currentVertex_Bulge = math.tan(data / 4)
-        --self.lwVertexes[#self.lwVertexes] = LWVertex2D(vertex:location(), self.currentVertex_Bulge, vertex:startWidth(), vertex:endWidth())
-
-		self.build:modifyLastVertex(data)
+		--self.build:modifyLastVertex(data)
     end
 end
 
---[[function LWPolylineOperations:getLWPolyline(vertexes)
-    if(#vertexes > 1) then
-        local layer = active_layer(self.target_widget)
-        local viewport = active_viewport(self.target_widget)
-        local metaInfo = active_metaInfo(self.target_widget)
-        local lwp = LWPolyline(vertexes, 1, 1, 1, false, Coord(0,0), layer, viewport, metaInfo)
-        lwp:setId(self.entity_id)
-
-        return lwp
-    else
-        return nil
-    end
-end ]]--
-
---[[function LWPolylineOperations:createTempVertex(point)
-    local location = self.currentVertex_Location
-    local bulge = self.currentVertex_Bulge
-
-    if(location == nil) then
-        location = Operations:getCoordinate(point)
-    elseif(bulge == nil) then
-        bulge = Operations:getDistance(location, point)
-    end
-
-    bulge = bulge or 1
-
-    return LWVertex2D(location, bulge)
-end ]]--
-
---[[function LWPolylineOperations:createTempLWPolyline(point)
-
-    local vertexes = {}
-    for k, v in pairs(self.lwVertexes) do
-        vertexes[k] = v
-    end
-    table.insert(vertexes, self:createTempVertex(point))
-
-    self.entity = self:getLWPolyline(vertexes)
-    self:refreshTempEntity()
-end--]]
-
-function LWPolylineOperations:createLWPolyline()
-    --local lwp = self:getLWPolyline(self.lwVertexes)
-    --self:createEntity(lwp)
+--[[function LWPolylineOperations:createLWPolyline()
 	self:createEntity()
+end]]--
+
+function LWPolylineOperations:refreshTempEntity()
+	if(#self.builder:getVertices() > 2) then
+        CreateOperations.refreshTempEntity(self)
+    end
 end
 
 function LWPolylineOperations:close()
-    --[[if(not self.finished) then
-        self:createLWPolyline()
-        CreateOperations.close(self)
-    end--]]
-	self:createEntity()
+	--self:createEntity()
 	CreateOperations.close(self)
 end
 
-function LWPolylineOperations:createArc()
+--[[function LWPolylineOperations:createArc()
     self.currentVertex = "arc"
 
     if(self.builder:getVertices() > 0) then
 		self.builder:modifyLastVertexArc()
-        --local vertex = self.lwVertexes[#self.lwVertexes]
-        --self.lwVertexes[#self.lwVertexes] = LWVertex2D(vertex:location(), self.currentVertex_Bulge, vertex:startWidth(), vertex:endWidth())
     end
 
     message("Give arc angle and coordinates", self.target_widget)
@@ -136,9 +68,7 @@ function LWPolylineOperations:createLine()
 
     if(self.builder:getVertices() > 0) then
 		self.builder:modifyLastVertexLine()
-        --local vertex = self.lwVertexes[#self.lwVertexes]
-        --self.lwVertexes[#self.lwVertexes] = LWVertex2D(vertex:location(), 0, vertex:startWidth(), vertex:endWidth())
     end
 
     message("Give line coordinates", self.target_widget)
-end
+end ]]--

--- a/lcUILua/createActions/lwpolylineoperations.lua
+++ b/lcUILua/createActions/lwpolylineoperations.lua
@@ -65,7 +65,12 @@ end
 function LWPolylineOperations:createArc()
     self.currentVertex = "arc"
 
-    if(#self.builder:getVertices() > 0) then
+    if(#self.builder:getVertices() > 1) then
+		if(self.tempPoint) then
+			self.builder:removeVertex(-1)
+			self.tempPoint = false
+		end
+
 		self.builder:modifyLastVertexArc()
     end
 
@@ -75,7 +80,12 @@ end
 function LWPolylineOperations:createLine()
     self.currentVertex = "line"
 
-    if(#self.builder:getVertices() > 0) then
+    if(#self.builder:getVertices() > 1) then
+		if(self.tempPoint) then
+			self.builder:removeVertex(-1)
+			self.tempPoint = false
+		end
+
 		self.builder:modifyLastVertexLine()
     end
 

--- a/lcUILua/createActions/lwpolylineoperations.lua
+++ b/lcUILua/createActions/lwpolylineoperations.lua
@@ -20,7 +20,6 @@ function LWPolylineOperations:enterPoint(eventName, data)
 	if(eventName == "point" or eventName == "number") then
         self:newData(data["position"])
     elseif(eventName == "mouseMove") then
-		--self.builder:createTempLWPolyline(data["position"])
 		self:refreshTempEntity()
     end
 end
@@ -34,29 +33,28 @@ function LWPolylineOperations:newData(data)
 			self.builder:addArcVertex(data)
         end
     else
-		--self.build:modifyLastVertex(data)
+		self.build:modifyLastVertex(data)
     end
 end
 
---[[function LWPolylineOperations:createLWPolyline()
-	self:createEntity()
-end]]--
-
 function LWPolylineOperations:refreshTempEntity()
-	if(#self.builder:getVertices() > 2) then
+	if(#self.builder:getVertices() > 1) then
         CreateOperations.refreshTempEntity(self)
     end
 end
 
 function LWPolylineOperations:close()
-	--self:createEntity()
-	CreateOperations.close(self)
+	if(self.creatingPolyspline == nil) then
+        self.creatingPolyspline = true
+        self:createEntity()
+        CreateOperations.close(self)
+    end
 end
 
---[[function LWPolylineOperations:createArc()
+function LWPolylineOperations:createArc()
     self.currentVertex = "arc"
 
-    if(self.builder:getVertices() > 0) then
+    if(#self.builder:getVertices() > 0) then
 		self.builder:modifyLastVertexArc()
     end
 
@@ -66,9 +64,9 @@ end
 function LWPolylineOperations:createLine()
     self.currentVertex = "line"
 
-    if(self.builder:getVertices() > 0) then
+    if(#self.builder:getVertices() > 0) then
 		self.builder:modifyLastVertexLine()
     end
 
     message("Give line coordinates", self.target_widget)
-end ]]--
+end

--- a/lcUILua/ui/mainwindow.lua
+++ b/lcUILua/ui/mainwindow.lua
@@ -125,8 +125,8 @@ local function create_menu(mainWindow, widget, commandLine, id)
 
 	-- connect draw menu options
 	luaInterface:luaConnect(lineAction, "triggered(bool)", function() run_basic_operation(id, LineOperations) end)
-	luaInterface:luaConnect(circleAction, "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
-	luaInterface:luaConnect(arcAction, "triggered(bool)", function() run_basic_operation(id, ArcOperations) end)
+	luaInterface:luaConnect(circleAction, "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_default()  end)
+	luaInterface:luaConnect(arcAction, "triggered(bool)", function() op = run_basic_operation(id, ArcOperations); op:_init_3p() end)
 	luaInterface:luaConnect(ellipseAction, "triggered(bool)", function() run_basic_operation(id, EllipseOperations) end)
 	luaInterface:luaConnect(splineAction, "triggered(bool)", function() run_basic_operation(id, SplineOperations) end)
 	luaInterface:luaConnect(polylineAction, "triggered(bool)", function() create_lw_polyline(id) end)
@@ -138,11 +138,15 @@ local function connect_buttons(mainWindow, id)
 	luaInterface:luaConnect(mainWindow:findChild("action2_Point_Line"), "triggered(bool)", function() run_basic_operation(id, LineOperations) end)
 	
 	-- circle
-	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Radius"), "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
-	--luaInterface:luaConnect(mainWindow:findChild("actionCenter_Diameter"), "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Radius"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_cr()  end)
+	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Diameter"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_cd() end)
+	luaInterface:luaConnect(mainWindow:findChild("action2_Point_Circle"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_2p() end)
+	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Circle_2"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_3p() end)
+	luaInterface:luaConnect(mainWindow:findChild("actionTan_Tan_Radius"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_3t() end)
+	luaInterface:luaConnect(mainWindow:findChild("actionTan_Tan_Tan"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_2t() end)
 
 	-- arc
-	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Arc"), "triggered(bool)", function() run_basic_operation(id, ArcOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Arc"), "triggered(bool)", function() op = run_basic_operation(id, ArcOperations); op:_init_3p() end)
 
 	-- ellipse
 	luaInterface:luaConnect(mainWindow:findChild("actionEllipse"), "triggered(bool)", function() run_basic_operation(id, EllipseOperations) end)

--- a/lcUILua/ui/mainwindow.lua
+++ b/lcUILua/ui/mainwindow.lua
@@ -147,6 +147,7 @@ local function connect_buttons(mainWindow, id)
 
 	-- arc
 	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Arc"), "triggered(bool)", function() op = run_basic_operation(id, ArcOperations); op:_init_3p() end)
+	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Start_End_2"), "triggered(bool)", function() op = run_basic_operation(id, ArcOperations); op:_init_cse() end)
 
 	-- ellipse
 	luaInterface:luaConnect(mainWindow:findChild("actionEllipse"), "triggered(bool)", function() run_basic_operation(id, EllipseOperations) end)

--- a/lcUILua/ui/mainwindow.lua
+++ b/lcUILua/ui/mainwindow.lua
@@ -139,6 +139,7 @@ local function connect_buttons(mainWindow, id)
 	
 	-- circle
 	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Radius"), "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
+	--luaInterface:luaConnect(mainWindow:findChild("actionCenter_Diameter"), "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
 
 	-- arc
 	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Arc"), "triggered(bool)", function() run_basic_operation(id, ArcOperations) end)
@@ -151,6 +152,13 @@ local function connect_buttons(mainWindow, id)
 
 	-- polylines
 	luaInterface:luaConnect(mainWindow:findChild("actionPolyline"), "triggered(bool)", function() create_lw_polyline(id) end)
+
+	--dimensions
+	luaInterface:luaConnect(mainWindow:findChild("actionLinear"), "triggered(bool)", function() run_basic_operation(id, DimLinearOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("actionAligned"), "triggered(bool)", function() run_basic_operation(id, DimAlignedOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("actionRadius"), "triggered(bool)", function() run_basic_operation(id, DimRadialOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("actionDiameter"), "triggered(bool)", function() run_basic_operation(id, DimDiametricOperations) end)
+	luaInterface:luaConnect(mainWindow:findChild("actionANG3PT"), "triggered(bool)", function() run_basic_operation(id, DimAngularOperations) end)
 end
 
 --Create a new window

--- a/lcUILua/ui/mainwindow.lua
+++ b/lcUILua/ui/mainwindow.lua
@@ -84,12 +84,15 @@ local  function changelcTolerance(id)
 end
 
 --Create main window menu
-local function create_menu(mainWindow, widget, commandLine)
+local function create_menu(mainWindow, widget, commandLine, id)
     local menuBar = mainWindow:menuBar()
     local drawMenu = menuBar:addMenuStr(qt.QString("Draw"))
     local lineAction = drawMenu:addActionStr(qt.QString("Line"))
     local circleAction = drawMenu:addActionStr(qt.QString("Circle"))
     local arcAction = drawMenu:addActionStr(qt.QString("Arc"))
+	local ellipseAction = drawMenu:addActionStr(qt.QString("Ellipse"))
+	local splineAction = drawMenu:addActionStr(qt.QString("Spline"))
+	local polylineAction = drawMenu:addActionStr(qt.QString("Polyline"))
 
     local luaMenu = menuBar:addMenuStr(qt.QString("Lua"))
     local luaScriptAction = luaMenu:addActionStr(qt.QString("Run script"))
@@ -119,6 +122,35 @@ local function create_menu(mainWindow, widget, commandLine)
         open_lua_script(widget, commandLine)
     end)
     luaInterface:luaConnect(lcTolerance, "triggered(bool)", changelcTolerance)
+
+	-- connect draw menu options
+	luaInterface:luaConnect(lineAction, "triggered(bool)", function() run_basic_operation(id, LineOperations) end)
+	luaInterface:luaConnect(circleAction, "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
+	luaInterface:luaConnect(arcAction, "triggered(bool)", function() run_basic_operation(id, ArcOperations) end)
+	luaInterface:luaConnect(ellipseAction, "triggered(bool)", function() run_basic_operation(id, EllipseOperations) end)
+	luaInterface:luaConnect(splineAction, "triggered(bool)", function() run_basic_operation(id, SplineOperations) end)
+	luaInterface:luaConnect(polylineAction, "triggered(bool)", function() create_lw_polyline(id) end)
+end
+
+-- Connect menu buttons in the menu bar
+local function connect_buttons(mainWindow, id)
+	-- line
+	luaInterface:luaConnect(mainWindow:findChild("action2_Point_Line"), "triggered(bool)", function() run_basic_operation(id, LineOperations) end)
+	
+	-- circle
+	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Radius"), "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
+
+	-- arc
+	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Arc"), "triggered(bool)", function() run_basic_operation(id, ArcOperations) end)
+
+	-- ellipse
+	luaInterface:luaConnect(mainWindow:findChild("actionEllipse"), "triggered(bool)", function() run_basic_operation(id, EllipseOperations) end)
+
+	-- spline
+	luaInterface:luaConnect(mainWindow:findChild("actionSpline"), "triggered(bool)", function() run_basic_operation(id, SplineOperations) end)
+
+	-- polylines
+	luaInterface:luaConnect(mainWindow:findChild("actionPolyline"), "triggered(bool)", function() create_lw_polyline(id) end)
 end
 
 --Create a new window
@@ -147,7 +179,8 @@ function create_new_window(widget)
     add_toolbar(mainWindow, id, linePatternSelect, lineWidthSelect, colorSelect)
     addCadMdiChild(widget, id, commandLine)
 
-    create_menu(mainWindow, widget, commandLine)
+    create_menu(mainWindow, widget, commandLine, id)
+	connect_buttons(mainWindow, id)
 
     if(hideUI ~= true) then
         mainWindow:showMaximized()

--- a/lcUILua/ui/operations.lua
+++ b/lcUILua/ui/operations.lua
@@ -38,6 +38,8 @@ function run_basic_operation(id, operation, ...)
     finish_operation(id)
     create_cancel_button(id)
     luaInterface:setOperation(id, operation(id, ...))
+	op = luaInterface:operation(id)
+	return op
 end
 
 function create_lw_polyline(id)

--- a/lcadluascript/bridge/lc_builder.cpp
+++ b/lcadluascript/bridge/lc_builder.cpp
@@ -256,7 +256,6 @@ void import_lc_builder_namespace(kaguya::State& state) {
 		.addFunction("modifyLastVertex", &lc::builder::LWPolylineBuilder::modifyLastVertex)
 		.addFunction("modifyLastVertexArc", &lc::builder::LWPolylineBuilder::modifyLastVertexArc)
 		.addFunction("modifyLastVertexLine", &lc::builder::LWPolylineBuilder::modifyLastVertexLine)
-		.addFunction("createTempLWPolyline", &lc::builder::LWPolylineBuilder::createTempLWPolyline)
 		.addFunction("removeVertex", &lc::builder::LWPolylineBuilder::removeVertex)
 		.addFunction("getVertices", &lc::builder::LWPolylineBuilder::getVertices)
 		.addFunction("build", &lc::builder::LWPolylineBuilder::build)

--- a/lcadluascript/bridge/lc_builder.cpp
+++ b/lcadluascript/bridge/lc_builder.cpp
@@ -249,6 +249,18 @@ void import_lc_builder_namespace(kaguya::State& state) {
         .addFunction("startTangent", &lc::builder::SplineBuilder::startTangent)
     );
 
+	state["lc"]["builder"]["LWPolylineBuilder"].setClass(kaguya::UserdataMetatable<lc::builder::LWPolylineBuilder, lc::builder::CADEntityBuilder>()
+		.setConstructors<lc::builder::LWPolylineBuilder()>()
+		.addFunction("addLineVertex", &lc::builder::LWPolylineBuilder::addLineVertex)
+		.addFunction("addArcVertex", &lc::builder::LWPolylineBuilder::addArcVertex)
+		.addFunction("modifyLastVertex", &lc::builder::LWPolylineBuilder::modifyLastVertex)
+		.addFunction("modifyLastVertexArc", &lc::builder::LWPolylineBuilder::modifyLastVertexArc)
+		.addFunction("modifyLastVertexLine", &lc::builder::LWPolylineBuilder::modifyLastVertexLine)
+		.addFunction("createTempLWPolyline", &lc::builder::LWPolylineBuilder::createTempLWPolyline)
+		.addFunction("getVertices", &lc::builder::LWPolylineBuilder::getVertices)
+		.addFunction("build", &lc::builder::LWPolylineBuilder::build)
+	);
+
     state["lc"]["builder"]["InsertBuilder"].setClass(kaguya::UserdataMetatable<lc::builder::InsertBuilder, lc::builder::CADEntityBuilder>()
         .setConstructors<lc::builder::InsertBuilder()>()
         .addFunction("build", &lc::builder::InsertBuilder::build)

--- a/lcadluascript/bridge/lc_builder.cpp
+++ b/lcadluascript/bridge/lc_builder.cpp
@@ -257,6 +257,7 @@ void import_lc_builder_namespace(kaguya::State& state) {
 		.addFunction("modifyLastVertexArc", &lc::builder::LWPolylineBuilder::modifyLastVertexArc)
 		.addFunction("modifyLastVertexLine", &lc::builder::LWPolylineBuilder::modifyLastVertexLine)
 		.addFunction("createTempLWPolyline", &lc::builder::LWPolylineBuilder::createTempLWPolyline)
+		.addFunction("removeVertex", &lc::builder::LWPolylineBuilder::removeVertex)
 		.addFunction("getVertices", &lc::builder::LWPolylineBuilder::getVertices)
 		.addFunction("build", &lc::builder::LWPolylineBuilder::build)
 	);

--- a/lckernel/CMakeLists.txt
+++ b/lckernel/CMakeLists.txt
@@ -81,6 +81,7 @@ cad/builders/insert.cpp
 cad/builders/layer.cpp
 cad/builders/linepattern.cpp
 cad/builders/spline.cpp
+cad/builders/lwpolyline.cpp
 cad/meta/customentitystorage.cpp
 cad/operations/blockops.cpp
 cad/operations/builder.cpp

--- a/lckernel/cad/builders/lwpolyline.cpp
+++ b/lckernel/cad/builders/lwpolyline.cpp
@@ -9,9 +9,7 @@ lc::builder::LWPolylineBuilder::LWPolylineBuilder()
 	_currentVertex_StartWidth(0),
 	_currentVertex_EndWidth(0),
 	_currentVertex_Location()
-{
-
-}
+{}
 
 void lc::builder::LWPolylineBuilder::addLineVertex(const lc::geo::Coordinate& vert)
 {

--- a/lckernel/cad/builders/lwpolyline.cpp
+++ b/lckernel/cad/builders/lwpolyline.cpp
@@ -1,0 +1,77 @@
+#include "lwpolyline.h"
+#include "cad/primitive/lwpolyline.h"
+#include "cad/interface/metatype.h"
+#include <math.h>
+
+lc::builder::LWPolylineBuilder::LWPolylineBuilder()
+	:
+	_currentVertex_Bulge(1),
+	_currentVertex_StartWidth(0),
+	_currentVertex_EndWidth(0),
+	_currentVertex_Location()
+{
+
+}
+
+void lc::builder::LWPolylineBuilder::addLineVertex(const lc::geo::Coordinate& vert)
+{
+	_vertices.push_back(lc::builder::LWBuilderVertex(vert, 0));
+	_currentVertex_Location = vert;
+}
+
+void lc::builder::LWPolylineBuilder::addArcVertex(const lc::geo::Coordinate& vert)
+{
+	_vertices.push_back(lc::builder::LWBuilderVertex(vert, _currentVertex_Bulge));
+	_currentVertex_Location = vert;
+}
+
+void lc::builder::LWPolylineBuilder::modifyLastVertex(const geo::Coordinate& data)
+{
+	int n = _vertices.size();
+	lc::builder::LWBuilderVertex& vert = _vertices[n - 1];
+	_currentVertex_Bulge = tan(data.magnitude() / 4);
+	_vertices[n - 1] = lc::builder::LWBuilderVertex(vert.location, vert.startWidth, vert.endWidth, _currentVertex_Bulge);
+}
+
+void lc::builder::LWPolylineBuilder::modifyLastVertexArc(geo::Coordinate data)
+{
+	int n = _vertices.size();
+	lc::builder::LWBuilderVertex& vert = _vertices[n - 1];(data / 4);
+	_vertices[n - 1] = lc::builder::LWBuilderVertex(vert.location, vert.startWidth, vert.endWidth, _currentVertex_Bulge);
+}
+
+void lc::builder::LWPolylineBuilder::modifyLastVertexLine(geo::Coordinate data)
+{
+	int n = _vertices.size();
+	lc::builder::LWBuilderVertex& vert = _vertices[n - 1];
+	_vertices[n - 1] = lc::builder::LWBuilderVertex(vert.location, vert.startWidth, vert.endWidth, 0);
+}
+
+std::vector<lc::builder::LWBuilderVertex>& lc::builder::LWPolylineBuilder::getVertices()
+{
+	return _vertices;
+}
+
+void lc::builder::LWPolylineBuilder::createTempLWPolyline(const geo::Coordinate& point)
+{
+	int n = _vertices.size();
+	std::vector<lc::builder::LWBuilderVertex> vertexes;
+	vertexes.reserve(n);
+	for (int i = 0; i < n; i++)
+	{
+		vertexes.push_back(_vertices[i]);
+	}
+
+	// create temp vertex location
+	geo::Coordinate location = this->_currentVertex_Location;
+	double bulge = this->_currentVertex_Bulge;
+
+	location = point;
+
+	vertexes.push_back(lc::builder::LWBuilderVertex(location, bulge));
+}
+
+lc::entity::LWPolyline_CSPtr lc::builder::LWPolylineBuilder::build()
+{
+	return lc::entity::LWPolyline_CSPtr(new lc::entity::LWPolyline(*this));
+}

--- a/lckernel/cad/builders/lwpolyline.cpp
+++ b/lckernel/cad/builders/lwpolyline.cpp
@@ -45,28 +45,9 @@ void lc::builder::LWPolylineBuilder::modifyLastVertexLine()
 	_vertices[n - 1] = lc::builder::LWBuilderVertex(vert.location, vert.startWidth, vert.endWidth, 0);
 }
 
-std::vector<lc::builder::LWBuilderVertex>& lc::builder::LWPolylineBuilder::getVertices()
+const std::vector<lc::builder::LWBuilderVertex>& lc::builder::LWPolylineBuilder::getVertices()
 {
 	return _vertices;
-}
-
-void lc::builder::LWPolylineBuilder::createTempLWPolyline(const geo::Coordinate& point)
-{
-	int n = _vertices.size();
-	std::vector<lc::builder::LWBuilderVertex> vertexes;
-	vertexes.reserve(n);
-	for (int i = 0; i < n; i++)
-	{
-		vertexes.push_back(_vertices[i]);
-	}
-
-	// create temp vertex location
-	geo::Coordinate location = this->_currentVertex_Location;
-	double bulge = this->_currentVertex_Bulge;
-
-	location = point;
-
-	vertexes.push_back(lc::builder::LWBuilderVertex(location, bulge));
 }
 
 lc::entity::LWPolyline_CSPtr lc::builder::LWPolylineBuilder::build()

--- a/lckernel/cad/builders/lwpolyline.cpp
+++ b/lckernel/cad/builders/lwpolyline.cpp
@@ -75,3 +75,13 @@ lc::entity::LWPolyline_CSPtr lc::builder::LWPolylineBuilder::build()
 {
 	return lc::entity::LWPolyline_CSPtr(new lc::entity::LWPolyline(*this));
 }
+
+void lc::builder::LWPolylineBuilder::removeVertex(int index)
+{
+	if (index < 0) {
+		_vertices.erase(_vertices.end() + index);
+	}
+	else {
+		_vertices.erase(_vertices.begin() + index);
+	}
+}

--- a/lckernel/cad/builders/lwpolyline.cpp
+++ b/lckernel/cad/builders/lwpolyline.cpp
@@ -33,14 +33,14 @@ void lc::builder::LWPolylineBuilder::modifyLastVertex(const geo::Coordinate& dat
 	_vertices[n - 1] = lc::builder::LWBuilderVertex(vert.location, vert.startWidth, vert.endWidth, _currentVertex_Bulge);
 }
 
-void lc::builder::LWPolylineBuilder::modifyLastVertexArc(geo::Coordinate data)
+void lc::builder::LWPolylineBuilder::modifyLastVertexArc()
 {
 	int n = _vertices.size();
-	lc::builder::LWBuilderVertex& vert = _vertices[n - 1];(data / 4);
+	lc::builder::LWBuilderVertex& vert = _vertices[n - 1];
 	_vertices[n - 1] = lc::builder::LWBuilderVertex(vert.location, vert.startWidth, vert.endWidth, _currentVertex_Bulge);
 }
 
-void lc::builder::LWPolylineBuilder::modifyLastVertexLine(geo::Coordinate data)
+void lc::builder::LWPolylineBuilder::modifyLastVertexLine()
 {
 	int n = _vertices.size();
 	lc::builder::LWBuilderVertex& vert = _vertices[n - 1];

--- a/lckernel/cad/builders/lwpolyline.h
+++ b/lckernel/cad/builders/lwpolyline.h
@@ -39,6 +39,7 @@ namespace lc {
 				void modifyLastVertexArc();
 				void modifyLastVertexLine();
 				void createTempLWPolyline(const geo::Coordinate& point);
+				void removeVertex(int index);
 				std::vector<lc::builder::LWBuilderVertex>& getVertices();
 				lc::entity::LWPolyline_CSPtr build();
 		private:

--- a/lckernel/cad/builders/lwpolyline.h
+++ b/lckernel/cad/builders/lwpolyline.h
@@ -11,8 +11,8 @@ namespace lc {
 			{
 				location = v;
 				bulge = bul;
-				startWidth = 1;
-				endWidth = 1;
+				startWidth = 0;
+				endWidth = 0;
 			}
 
 			LWBuilderVertex(geo::Coordinate v, double startW, double endW, double bul)

--- a/lckernel/cad/builders/lwpolyline.h
+++ b/lckernel/cad/builders/lwpolyline.h
@@ -36,8 +36,8 @@ namespace lc {
 				void addLineVertex(const lc::geo::Coordinate& vert);
 				void addArcVertex(const lc::geo::Coordinate& vert);
 				void modifyLastVertex(const geo::Coordinate& vert);
-				void modifyLastVertexArc(geo::Coordinate data);
-				void modifyLastVertexLine(geo::Coordinate data);
+				void modifyLastVertexArc();
+				void modifyLastVertexLine();
 				void createTempLWPolyline(const geo::Coordinate& point);
 				std::vector<lc::builder::LWBuilderVertex>& getVertices();
 				lc::entity::LWPolyline_CSPtr build();

--- a/lckernel/cad/builders/lwpolyline.h
+++ b/lckernel/cad/builders/lwpolyline.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "cadentity.h"
+
+namespace lc {
+	namespace builder {
+
+		struct LWBuilderVertex
+		{
+			LWBuilderVertex(geo::Coordinate v, double bul)
+			{
+				location = v;
+				bulge = bul;
+				startWidth = 1;
+				endWidth = 1;
+			}
+
+			LWBuilderVertex(geo::Coordinate v, double startW, double endW, double bul)
+			{
+				location = v;
+				startWidth = startW;
+				endWidth = endW;
+				bulge = bul;
+			}
+
+			geo::Coordinate location;
+			double bulge;
+			double startWidth;
+			double endWidth;
+		};
+
+		class LWPolylineBuilder : public CADEntityBuilder {
+			public:
+				LWPolylineBuilder();
+				virtual ~LWPolylineBuilder() = default;
+				void addLineVertex(const lc::geo::Coordinate& vert);
+				void addArcVertex(const lc::geo::Coordinate& vert);
+				void modifyLastVertex(const geo::Coordinate& vert);
+				void modifyLastVertexArc(geo::Coordinate data);
+				void modifyLastVertexLine(geo::Coordinate data);
+				void createTempLWPolyline(const geo::Coordinate& point);
+				std::vector<lc::builder::LWBuilderVertex>& getVertices();
+				lc::entity::LWPolyline_CSPtr build();
+		private:
+			std::vector<lc::builder::LWBuilderVertex> _vertices;
+			double _currentVertex_Bulge;
+			double _currentVertex_StartWidth;
+			double _currentVertex_EndWidth;
+			geo::Coordinate _currentVertex_Location;
+		};
+
+	}
+}

--- a/lckernel/cad/builders/lwpolyline.h
+++ b/lckernel/cad/builders/lwpolyline.h
@@ -38,9 +38,8 @@ namespace lc {
 				void modifyLastVertex(const geo::Coordinate& vert);
 				void modifyLastVertexArc();
 				void modifyLastVertexLine();
-				void createTempLWPolyline(const geo::Coordinate& point);
 				void removeVertex(int index);
-				std::vector<lc::builder::LWBuilderVertex>& getVertices();
+				const std::vector<lc::builder::LWBuilderVertex>& getVertices();
 				lc::entity::LWPolyline_CSPtr build();
 		private:
 			std::vector<lc::builder::LWBuilderVertex> _vertices;

--- a/lckernel/cad/primitive/lwpolyline.cpp
+++ b/lckernel/cad/primitive/lwpolyline.cpp
@@ -55,9 +55,9 @@ LWPolyline::LWPolyline(lc::builder::LWPolylineBuilder& builder)
 	_closed(false),
 	_extrusionDirection(lc::geo::Coordinate(0, 0))
 {
-	std::vector<lc::builder::LWBuilderVertex> builderVerts = builder.getVertices();
+	const std::vector<lc::builder::LWBuilderVertex>& builderVerts = builder.getVertices();
 
-	for (lc::builder::LWBuilderVertex vert : builder.getVertices())
+	for (const lc::builder::LWBuilderVertex& vert : builderVerts)
 	{
 		_vertex.emplace_back(LWVertex2D(vert.location, vert.bulge, vert.startWidth, vert.endWidth));
 	}

--- a/lckernel/cad/primitive/lwpolyline.cpp
+++ b/lckernel/cad/primitive/lwpolyline.cpp
@@ -61,6 +61,8 @@ LWPolyline::LWPolyline(lc::builder::LWPolylineBuilder& builder)
 	{
 		_vertex.emplace_back(LWVertex2D(vert.location, vert.bulge, vert.startWidth, vert.endWidth));
 	}
+
+	generateEntities();
 }
 
 CADEntity_CSPtr LWPolyline::move(const geo::Coordinate& offset) const {

--- a/lckernel/cad/primitive/lwpolyline.cpp
+++ b/lckernel/cad/primitive/lwpolyline.cpp
@@ -7,6 +7,7 @@
 #include <cad/interface/snapable.h>
 #include <cad/primitive/arc.h>
 #include <cad/primitive/line.h>
+#include "lwpolyline.h"
 
 using namespace lc;
 using namespace entity;
@@ -42,6 +43,24 @@ LWPolyline::LWPolyline(const LWPolyline_CSPtr& other, bool sameID) :
         _closed(other->_closed),
         _extrusionDirection(other->_extrusionDirection) {
     generateEntities();
+}
+
+LWPolyline::LWPolyline(lc::builder::LWPolylineBuilder& builder)
+	:
+	CADEntity(builder),
+	_vertex(),
+	_width(1),
+	_elevation(1),
+	_tickness(1),
+	_closed(false),
+	_extrusionDirection(lc::geo::Coordinate(0, 0))
+{
+	std::vector<lc::builder::LWBuilderVertex> builderVerts = builder.getVertices();
+
+	for (lc::builder::LWBuilderVertex vert : builder.getVertices())
+	{
+		_vertex.emplace_back(LWVertex2D(vert.location, vert.bulge, vert.startWidth, vert.endWidth));
+	}
 }
 
 CADEntity_CSPtr LWPolyline::move(const geo::Coordinate& offset) const {

--- a/lckernel/cad/primitive/lwpolyline.cpp
+++ b/lckernel/cad/primitive/lwpolyline.cpp
@@ -48,21 +48,26 @@ LWPolyline::LWPolyline(const LWPolyline_CSPtr& other, bool sameID) :
 LWPolyline::LWPolyline(lc::builder::LWPolylineBuilder& builder)
 	:
 	CADEntity(builder),
-	_vertex(),
+	_vertex(generateVertexFromBuilderVertex(builder.getVertices())),
 	_width(1),
 	_elevation(1),
 	_tickness(1),
 	_closed(false),
 	_extrusionDirection(lc::geo::Coordinate(0, 0))
 {
-	const std::vector<lc::builder::LWBuilderVertex>& builderVerts = builder.getVertices();
+	generateEntities();
+}
+
+std::vector<LWVertex2D> LWPolyline::generateVertexFromBuilderVertex(const std::vector<lc::builder::LWBuilderVertex>& builderVerts) const
+{
+	std::vector<LWVertex2D> verts;
 
 	for (const lc::builder::LWBuilderVertex& vert : builderVerts)
 	{
-		_vertex.emplace_back(LWVertex2D(vert.location, vert.bulge, vert.startWidth, vert.endWidth));
+		verts.emplace_back(LWVertex2D(vert.location, vert.bulge, vert.startWidth, vert.endWidth));
 	}
 
-	generateEntities();
+	return verts;
 }
 
 CADEntity_CSPtr LWPolyline::move(const geo::Coordinate& offset) const {

--- a/lckernel/cad/primitive/lwpolyline.h
+++ b/lckernel/cad/primitive/lwpolyline.h
@@ -162,7 +162,14 @@ namespace lc {
              */
             void generateEntities();
 
-            std::vector<LWVertex2D> _vertex;
+			/** 
+			 * @brief Helper method to generate vertex data from passed in builder vertex struct in constructor
+			 * @param vector of LWBuilderVertex
+			 * @return vector of LWVertex2D
+			 */
+			std::vector<LWVertex2D> generateVertexFromBuilderVertex(const std::vector<lc::builder::LWBuilderVertex>& builderVerts) const;
+
+            const std::vector<LWVertex2D> _vertex;
             const double _width;
             const double _elevation;
             const double _tickness;

--- a/lckernel/cad/primitive/lwpolyline.h
+++ b/lckernel/cad/primitive/lwpolyline.h
@@ -11,6 +11,8 @@
 #include "cad/interface/draggable.h"
 #include <vector>
 
+#include <cad/builders/lwpolyline.h>
+
 namespace lc {
     namespace entity {
         /**
@@ -118,6 +120,7 @@ namespace lc {
 
             LWPolyline(const LWPolyline_CSPtr& other, bool sameID = false);
 
+			LWPolyline(lc::builder::LWPolylineBuilder& builder);
 
             double width() const {
                 return _width;
@@ -159,7 +162,7 @@ namespace lc {
              */
             void generateEntities();
 
-            const std::vector<LWVertex2D> _vertex;
+            std::vector<LWVertex2D> _vertex;
             const double _width;
             const double _elevation;
             const double _tickness;


### PR DESCRIPTION
Changes for LWPolyline :-

1) Added LWPolylineBuilder class and added constructor to LWPolyline primitive. Also added necessary lines to the lcbuilder bridge.

2) Updated lwpolyline.lua.

Changes for previous PR -

1) Added connect calls to the mainwindow.lua file to run appropriate actions on clicking their respective buttons in the create and draw menu.

2) Added Ellipse, Spline and Polyline to draw menu.

3) Changed operations.lua to return a lua reference, so that functions can be called by the calling function.

4) Refactored circleoperations.lua and arcoperations.lua so that _init function only contains initialization. 

5) Options under draw menu call the init_default whereas those under the create menu call their respective init methods.
