### PR TITLE
Added custom titlebar to widget

### DIFF
--- a/lcUI/CMakeLists.txt
+++ b/lcUI/CMakeLists.txt
@@ -42,6 +42,7 @@ widgets/linepatternpathpart.h
 widgets/linepatternmodel.h
 widgets/linewidthselect.h
 widgets/colorselect.h
+widgets/widgettitlebar.h
 lua/qtbridge.h
 lua/luaqobject.h
 dialogs/addlayerdialog.h
@@ -71,6 +72,7 @@ widgets/linepatternpathpart.cpp
 widgets/linepatternmodel.cpp
 widgets/linewidthselect.cpp
 widgets/colorselect.cpp
+widgets/widgettitlebar.cpp
 lua/qtbridge.cpp
 lua/luaqobject.cpp
 dialogs/addlayerdialog.cpp

--- a/lcUI/widgets/clicommand.cpp
+++ b/lcUI/widgets/clicommand.cpp
@@ -31,7 +31,9 @@ CliCommand::CliCommand(QWidget* parent) :
 
     ui->command->setCompleter(_completer.get());
 
-	WidgetTitleBar* titleBar = new WidgetTitleBar("CliCommand", this, false);
+
+	WidgetTitleBar* titleBar = new WidgetTitleBar( "Cli Command", this,
+													WidgetTitleBar::TitleBarOptions::HorizontalOnHidden);
 	this->setTitleBarWidget(titleBar);
 }
 

--- a/lcUI/widgets/clicommand.cpp
+++ b/lcUI/widgets/clicommand.cpp
@@ -30,6 +30,9 @@ CliCommand::CliCommand(QWidget* parent) :
     _completer->setModel(_commands.get());
 
     ui->command->setCompleter(_completer.get());
+
+	WidgetTitleBar* titleBar = new WidgetTitleBar("CliCommand", this, false);
+	this->setTitleBarWidget(titleBar);
 }
 
 CliCommand::~CliCommand() {
@@ -208,4 +211,10 @@ void CliCommand::returnText(bool returnText) {
 
 void CliCommand::commandActive(bool commandActive) {
     _commandActive = commandActive;
+}
+
+void CliCommand::closeEvent(QCloseEvent* event)
+{
+	this->widget()->hide();
+	event->ignore();
 }

--- a/lcUI/widgets/clicommand.h
+++ b/lcUI/widgets/clicommand.h
@@ -9,6 +9,8 @@
 #include <memory>
 #include <cad/geometry/geocoordinate.h>
 
+#include "widgettitlebar.h"
+
 namespace Ui {
     class CliCommand;
 }
@@ -100,6 +102,8 @@ namespace lc {
                     void enterCoordinate(QString coordinate);
 
                     void enterNumber(double number);
+
+					void closeEvent(QCloseEvent* event);
 
                     Ui::CliCommand* ui;
                     std::shared_ptr<QCompleter> _completer;

--- a/lcUI/widgets/layers.cpp
+++ b/lcUI/widgets/layers.cpp
@@ -201,7 +201,6 @@ void Layers::onSelectionChanged(const QItemSelection& selected, const QItemSelec
 
 void Layers::closeEvent(QCloseEvent* event)
 {
-	this->setFeatures(QDockWidget::DockWidgetVerticalTitleBar);
 	this->widget()->hide();
 	event->ignore();
 }

--- a/lcUI/widgets/layers.cpp
+++ b/lcUI/widgets/layers.cpp
@@ -24,6 +24,9 @@ Layers::Layers(CadMdiChild* mdiChild, QWidget *parent) :
     connect(model, &LayerModel::nameChanged, this, &Layers::changeLayerName);
     connect(ui->layerList->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)),
             this, SLOT(onSelectionChanged(const QItemSelection &, const QItemSelection &)));
+
+	WidgetTitleBar* titleBar = new WidgetTitleBar("Layers", this);
+	this->setTitleBarWidget(titleBar);
 }
 
 Layers::~Layers() {
@@ -194,4 +197,17 @@ void Layers::onSelectionChanged(const QItemSelection& selected, const QItemSelec
     auto layer = model->layerAt(selected.first().top());
     _mdiChild->setActiveLayer(layer);
     emit layerChanged(layer);
+}
+
+void Layers::closeEvent(QCloseEvent* event)
+{
+	this->setFeatures(QDockWidget::DockWidgetVerticalTitleBar);
+	this->widget()->hide();
+	event->ignore();
+}
+
+void Layers::showWidget()
+{
+	this->widget()->show();
+	this->setFeatures(this->features() & ~QDockWidget::DockWidgetVerticalTitleBar);
 }

--- a/lcUI/widgets/layers.cpp
+++ b/lcUI/widgets/layers.cpp
@@ -205,9 +205,3 @@ void Layers::closeEvent(QCloseEvent* event)
 	this->widget()->hide();
 	event->ignore();
 }
-
-void Layers::showWidget()
-{
-	this->widget()->show();
-	this->setFeatures(this->features() & ~QDockWidget::DockWidgetVerticalTitleBar);
-}

--- a/lcUI/widgets/layers.cpp
+++ b/lcUI/widgets/layers.cpp
@@ -25,7 +25,8 @@ Layers::Layers(CadMdiChild* mdiChild, QWidget *parent) :
     connect(ui->layerList->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)),
             this, SLOT(onSelectionChanged(const QItemSelection &, const QItemSelection &)));
 
-	WidgetTitleBar* titleBar = new WidgetTitleBar("Layers", this, true);
+	WidgetTitleBar* titleBar = new WidgetTitleBar( "Layers", this,
+													WidgetTitleBar::TitleBarOptions::VerticalOnHidden);
 	this->setTitleBarWidget(titleBar);
 }
 

--- a/lcUI/widgets/layers.cpp
+++ b/lcUI/widgets/layers.cpp
@@ -25,7 +25,7 @@ Layers::Layers(CadMdiChild* mdiChild, QWidget *parent) :
     connect(ui->layerList->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)),
             this, SLOT(onSelectionChanged(const QItemSelection &, const QItemSelection &)));
 
-	WidgetTitleBar* titleBar = new WidgetTitleBar("Layers", this);
+	WidgetTitleBar* titleBar = new WidgetTitleBar("Layers", this, true);
 	this->setTitleBarWidget(titleBar);
 }
 

--- a/lcUI/widgets/layers.h
+++ b/lcUI/widgets/layers.h
@@ -57,8 +57,6 @@ namespace lc {
 
                     void changeLayerName(lc::meta::Layer_CSPtr& layer, const std::string& name);
 
-					void showWidget();
-
                 protected:
                     Ui::Layers* ui;
                     LayerModel* model;

--- a/lcUI/widgets/layers.h
+++ b/lcUI/widgets/layers.h
@@ -40,7 +40,6 @@ namespace lc {
                      * Update the layer list.
                      */
                     void setMdiChild(CadMdiChild* mdiChild = nullptr);
-					void closeEvent(QCloseEvent* event);
                 signals:
 
                     void layerChanged(lc::meta::Layer_CSPtr layer);
@@ -77,6 +76,8 @@ namespace lc {
                     void on_removeLayerEvent(const lc::event::RemoveLayerEvent&);
 
                     void on_replaceLayerEvent(const lc::event::ReplaceLayerEvent&);
+
+					void closeEvent(QCloseEvent* event);
             };
         }
     }

--- a/lcUI/widgets/layers.h
+++ b/lcUI/widgets/layers.h
@@ -11,6 +11,7 @@
 #include "dialogs/addlayerdialog.h"
 #include "layermodel.h"
 #include <cad/operations/layerops.h>
+#include "widgettitlebar.h"
 
 namespace Ui {
     class Layers;
@@ -39,7 +40,7 @@ namespace lc {
                      * Update the layer list.
                      */
                     void setMdiChild(CadMdiChild* mdiChild = nullptr);
-
+					void closeEvent(QCloseEvent* event);
                 signals:
 
                     void layerChanged(lc::meta::Layer_CSPtr layer);
@@ -55,6 +56,8 @@ namespace lc {
                     void on_layerList_clicked(const QModelIndex& index);
 
                     void changeLayerName(lc::meta::Layer_CSPtr& layer, const std::string& name);
+
+					void showWidget();
 
                 protected:
                     Ui::Layers* ui;

--- a/lcUI/widgets/toolbar.cpp
+++ b/lcUI/widgets/toolbar.cpp
@@ -12,7 +12,10 @@ Toolbar::Toolbar(QWidget *parent) :
 	setTitleBarWidget(nullptr);
 	setWidget(ui->tabWidget);
 
-	WidgetTitleBar* titleBar = new WidgetTitleBar("Toolbar", this, false);
+
+	WidgetTitleBar* titleBar = new WidgetTitleBar( "Toolbar", this,
+													WidgetTitleBar::TitleBarOptions::HorizontalOnHidden);
+
 	this->setTitleBarWidget(titleBar);
 }
 

--- a/lcUI/widgets/toolbar.cpp
+++ b/lcUI/widgets/toolbar.cpp
@@ -1,5 +1,6 @@
 #include "toolbar.h"
 #include "ui_toolbar.h"
+#include "widgettitlebar.h"
 
 using namespace lc::ui::widgets;
 
@@ -10,6 +11,9 @@ Toolbar::Toolbar(QWidget *parent) :
 	ui->setupUi(this);
 	setTitleBarWidget(nullptr);
 	setWidget(ui->tabWidget);
+
+	WidgetTitleBar* titleBar = new WidgetTitleBar("Toolbar", this, false);
+	this->setTitleBarWidget(titleBar);
 }
 
 Toolbar::~Toolbar() {
@@ -39,4 +43,10 @@ ToolbarTab* Toolbar::tabByName(const char *name) {
 	}
 
 	return nullptr;
+}
+
+void Toolbar::closeEvent(QCloseEvent* event)
+{
+	this->widget()->hide();
+	event->ignore();
 }

--- a/lcUI/widgets/toolbar.h
+++ b/lcUI/widgets/toolbar.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDockWidget>
+#include <QCloseEvent>
 #include "toolbartab.h"
 
 namespace Ui {
@@ -42,6 +43,7 @@ namespace lc {
                      * \return Pointer to ToolbarTab
                      */
                     ToolbarTab* tabByName(const char* name);
+					void closeEvent(QCloseEvent* event);
 
                 private:
                     Ui::Toolbar* ui;

--- a/lcUI/widgets/widgettitlebar.cpp
+++ b/lcUI/widgets/widgettitlebar.cpp
@@ -1,0 +1,50 @@
+#include "widgettitlebar.h"
+#include "layers.h"
+
+using namespace lc;
+using namespace lc::ui;
+using namespace lc::ui::widgets;
+
+WidgetTitleBar::WidgetTitleBar(const QString& title, QDockWidget* parent)
+	: QWidget(parent)
+{
+	pDock = parent;
+
+	m_pMainVLayout = new QVBoxLayout(this);
+
+	m_pLabel = new QLabel(title, this);
+	m_pMainVLayout->addWidget(m_pLabel);
+
+	m_pExpandButton = new QPushButton(this);
+	m_pCloseButton = new QPushButton(this);
+
+	QIcon icon1 = pDock->style()->standardIcon(QStyle::SP_TitleBarMaxButton, 0, pDock);
+	QIcon icon2 = pDock->style()->standardIcon(QStyle::SP_TitleBarCloseButton, 0, pDock);
+
+	m_pExpandButton->setIcon(icon1);
+	m_pCloseButton->setIcon(icon2);
+
+	m_pExpandButton->hide();
+
+	Layers* parentObj = (Layers*)parent;
+
+	connect(m_pExpandButton, SIGNAL(clicked()), parentObj, SLOT(showWidget()));
+	connect(m_pExpandButton, SIGNAL(clicked()), this, SLOT(expandButtonTriggered()));
+	connect(m_pCloseButton, SIGNAL(clicked()), this, SLOT(closeButtonTriggered()));
+
+	m_pMainVLayout->addWidget(m_pExpandButton);
+	m_pMainVLayout->addWidget(m_pCloseButton);
+}
+
+void WidgetTitleBar::expandButtonTriggered()
+{
+	m_pCloseButton->show();
+	m_pExpandButton->hide();
+}
+
+void WidgetTitleBar::closeButtonTriggered()
+{
+	m_pCloseButton->hide();
+	m_pExpandButton->show();
+	pDock->close();
+}

--- a/lcUI/widgets/widgettitlebar.cpp
+++ b/lcUI/widgets/widgettitlebar.cpp
@@ -38,9 +38,9 @@ WidgetTitleBar::WidgetTitleBar(const QString& title, QDockWidget* parent, bool v
 		m_pLabel->hide();
 	}
 
+	// add approriate icons for close and expand button
 	QIcon icon1 = pDock->style()->standardIcon(QStyle::SP_TitleBarMaxButton, 0, pDock);
 	QIcon icon2 = pDock->style()->standardIcon(QStyle::SP_TitleBarCloseButton, 0, pDock);
-
 	m_pExpandButton->setIcon(icon1);
 	m_pCloseButton->setIcon(icon2);
 
@@ -58,8 +58,6 @@ void WidgetTitleBar::expandButtonTriggered()
 	setHorizontalLayout(!verticalOnHidden);
 
 	pDock->widget()->show();
-
-	//pDock->setFeatures(pDock->features() & ~QDockWidget::DockWidgetVerticalTitleBar);
 }
 
 void WidgetTitleBar::closeButtonTriggered()
@@ -69,7 +67,6 @@ void WidgetTitleBar::closeButtonTriggered()
 
 	setVerticalLayout(!verticalOnHidden);
 
-	//pDock->setFeatures(QDockWidget::DockWidgetVerticalTitleBar);
 	pDock->close();
 }
 
@@ -81,6 +78,7 @@ void WidgetTitleBar::setHorizontalLayout(bool switched)
 		return;
 	}
 
+	// Removes the widgets and destroys v layout
 	m_pMainVLayout->removeWidget(m_pRLabel);
 	m_pMainVLayout->removeWidget(m_pCloseButton);
 	m_pMainVLayout->removeWidget(m_pExpandButton);
@@ -88,6 +86,7 @@ void WidgetTitleBar::setHorizontalLayout(bool switched)
 	delete m_pMainVLayout;
 	m_pMainVLayout = nullptr;
 
+	// Initializes and adds widgets to h layout
 	m_pMainHLayout = new QHBoxLayout(this);
 	m_pMainHLayout->addWidget(m_pLabel);
 	m_pMainHLayout->addWidget(m_pCloseButton);
@@ -95,6 +94,7 @@ void WidgetTitleBar::setHorizontalLayout(bool switched)
 	m_pLabel->show();
 	m_pRLabel->hide();
 
+	// disable DockWidgetVerticalTitleBar feature
 	pDock->setFeatures(pDock->features() & ~QDockWidget::DockWidgetVerticalTitleBar);
 }
 
@@ -106,6 +106,7 @@ void WidgetTitleBar::setVerticalLayout(bool switched)
 		return;
 	}
 
+	// Removes the widgets and destroys h layout
 	m_pMainHLayout->removeWidget(m_pLabel);
 	m_pMainHLayout->removeWidget(m_pCloseButton);
 	m_pMainHLayout->removeWidget(m_pExpandButton);
@@ -113,6 +114,7 @@ void WidgetTitleBar::setVerticalLayout(bool switched)
 	delete m_pMainHLayout;
 	m_pMainHLayout = nullptr;
 
+	// Initializes and adds widgets to v layout
 	m_pMainVLayout = new QVBoxLayout(this);
 	m_pMainVLayout->addWidget(m_pRLabel);
 	m_pMainVLayout->addWidget(m_pCloseButton);
@@ -120,5 +122,6 @@ void WidgetTitleBar::setVerticalLayout(bool switched)
 	m_pRLabel->show();
 	m_pLabel->hide();
 
+	// enable DockWidgetVerticalTitleBar feature
 	pDock->setFeatures(QDockWidget::DockWidgetVerticalTitleBar);
 }

--- a/lcUI/widgets/widgettitlebar.cpp
+++ b/lcUI/widgets/widgettitlebar.cpp
@@ -13,6 +13,7 @@ WidgetTitleBar::WidgetTitleBar(const QString& title, QDockWidget* parent, bool v
 	this->verticalOnHidden = verticalOnHidden;
 
 	m_pLabel = new QLabel(title, this);
+	m_pRLabel = new RotatableLabel(title, this);
 	m_pExpandButton = new QPushButton(this);
 	m_pCloseButton = new QPushButton(this);
 
@@ -23,14 +24,18 @@ WidgetTitleBar::WidgetTitleBar(const QString& title, QDockWidget* parent, bool v
 		m_pMainHLayout->addWidget(m_pLabel);
 		m_pMainHLayout->addWidget(m_pExpandButton);
 		m_pMainHLayout->addWidget(m_pCloseButton);
+
+		m_pRLabel->hide();
 	}
 	else
 	{
 		m_pMainVLayout = new QVBoxLayout(this);
 
-		m_pMainVLayout->addWidget(m_pLabel);
+		m_pMainVLayout->addWidget(m_pRLabel);
 		m_pMainVLayout->addWidget(m_pExpandButton);
 		m_pMainVLayout->addWidget(m_pCloseButton);
+
+		m_pLabel->hide();
 	}
 
 	QIcon icon1 = pDock->style()->standardIcon(QStyle::SP_TitleBarMaxButton, 0, pDock);
@@ -53,7 +58,8 @@ void WidgetTitleBar::expandButtonTriggered()
 	setHorizontalLayout(!verticalOnHidden);
 
 	pDock->widget()->show();
-	pDock->setFeatures(pDock->features() & ~QDockWidget::DockWidgetVerticalTitleBar);
+
+	//pDock->setFeatures(pDock->features() & ~QDockWidget::DockWidgetVerticalTitleBar);
 }
 
 void WidgetTitleBar::closeButtonTriggered()
@@ -62,6 +68,8 @@ void WidgetTitleBar::closeButtonTriggered()
 	m_pExpandButton->show();
 
 	setVerticalLayout(!verticalOnHidden);
+
+	//pDock->setFeatures(QDockWidget::DockWidgetVerticalTitleBar);
 	pDock->close();
 }
 
@@ -73,7 +81,7 @@ void WidgetTitleBar::setHorizontalLayout(bool switched)
 		return;
 	}
 
-	m_pMainVLayout->removeWidget(m_pLabel);
+	m_pMainVLayout->removeWidget(m_pRLabel);
 	m_pMainVLayout->removeWidget(m_pCloseButton);
 	m_pMainVLayout->removeWidget(m_pExpandButton);
 
@@ -84,6 +92,10 @@ void WidgetTitleBar::setHorizontalLayout(bool switched)
 	m_pMainHLayout->addWidget(m_pLabel);
 	m_pMainHLayout->addWidget(m_pCloseButton);
 	m_pMainHLayout->addWidget(m_pExpandButton);
+	m_pLabel->show();
+	m_pRLabel->hide();
+
+	pDock->setFeatures(pDock->features() & ~QDockWidget::DockWidgetVerticalTitleBar);
 }
 
 void WidgetTitleBar::setVerticalLayout(bool switched)
@@ -102,7 +114,11 @@ void WidgetTitleBar::setVerticalLayout(bool switched)
 	m_pMainHLayout = nullptr;
 
 	m_pMainVLayout = new QVBoxLayout(this);
-	m_pMainVLayout->addWidget(m_pLabel);
+	m_pMainVLayout->addWidget(m_pRLabel);
 	m_pMainVLayout->addWidget(m_pCloseButton);
 	m_pMainVLayout->addWidget(m_pExpandButton);
+	m_pRLabel->show();
+	m_pLabel->hide();
+
+	pDock->setFeatures(QDockWidget::DockWidgetVerticalTitleBar);
 }

--- a/lcUI/widgets/widgettitlebar.cpp
+++ b/lcUI/widgets/widgettitlebar.cpp
@@ -10,13 +10,16 @@ WidgetTitleBar::WidgetTitleBar(const QString& title, QDockWidget* parent)
 {
 	pDock = parent;
 
-	m_pMainVLayout = new QVBoxLayout(this);
+	m_pMainHLayout = new QHBoxLayout(this);
 
 	m_pLabel = new QLabel(title, this);
-	m_pMainVLayout->addWidget(m_pLabel);
+	m_pMainHLayout->addWidget(m_pLabel);
 
 	m_pExpandButton = new QPushButton(this);
 	m_pCloseButton = new QPushButton(this);
+
+	m_pMainHLayout->addWidget(m_pExpandButton);
+	m_pMainHLayout->addWidget(m_pCloseButton);
 
 	QIcon icon1 = pDock->style()->standardIcon(QStyle::SP_TitleBarMaxButton, 0, pDock);
 	QIcon icon2 = pDock->style()->standardIcon(QStyle::SP_TitleBarCloseButton, 0, pDock);
@@ -31,20 +34,49 @@ WidgetTitleBar::WidgetTitleBar(const QString& title, QDockWidget* parent)
 	connect(m_pExpandButton, SIGNAL(clicked()), parentObj, SLOT(showWidget()));
 	connect(m_pExpandButton, SIGNAL(clicked()), this, SLOT(expandButtonTriggered()));
 	connect(m_pCloseButton, SIGNAL(clicked()), this, SLOT(closeButtonTriggered()));
-
-	m_pMainVLayout->addWidget(m_pExpandButton);
-	m_pMainVLayout->addWidget(m_pCloseButton);
 }
 
 void WidgetTitleBar::expandButtonTriggered()
 {
 	m_pCloseButton->show();
 	m_pExpandButton->hide();
+
+	setHorizontalLayout();
 }
 
 void WidgetTitleBar::closeButtonTriggered()
 {
 	m_pCloseButton->hide();
 	m_pExpandButton->show();
+
+	setVerticalLayout();
 	pDock->close();
+}
+
+void WidgetTitleBar::setHorizontalLayout()
+{
+	m_pMainVLayout->removeWidget(m_pLabel);
+	m_pMainVLayout->removeWidget(m_pCloseButton);
+	m_pMainVLayout->removeWidget(m_pExpandButton);
+
+	delete m_pMainVLayout;
+
+	m_pMainHLayout = new QHBoxLayout(this);
+	m_pMainHLayout->addWidget(m_pLabel);
+	m_pMainHLayout->addWidget(m_pCloseButton);
+	m_pMainHLayout->addWidget(m_pExpandButton);
+}
+
+void WidgetTitleBar::setVerticalLayout()
+{
+	m_pMainHLayout->removeWidget(m_pLabel);
+	m_pMainHLayout->removeWidget(m_pCloseButton);
+	m_pMainHLayout->removeWidget(m_pExpandButton);
+
+	delete m_pMainHLayout;
+
+	m_pMainVLayout = new QVBoxLayout(this);
+	m_pMainVLayout->addWidget(m_pLabel);
+	m_pMainVLayout->addWidget(m_pCloseButton);
+	m_pMainVLayout->addWidget(m_pExpandButton);
 }

--- a/lcUI/widgets/widgettitlebar.cpp
+++ b/lcUI/widgets/widgettitlebar.cpp
@@ -5,37 +5,27 @@ using namespace lc;
 using namespace lc::ui;
 using namespace lc::ui::widgets;
 
-WidgetTitleBar::WidgetTitleBar(const QString& title, QDockWidget* parent, bool verticalOnHidden)
-	: QWidget(parent)
+WidgetTitleBar::WidgetTitleBar( const QString& title,
+								QDockWidget* parent,
+								WidgetTitleBar::TitleBarOptions hideOptions)
+	: QWidget(parent), m_pMainHLayout(nullptr), m_pMainVLayout(nullptr)
 {
 	pDock = parent;
 
-	this->verticalOnHidden = verticalOnHidden;
+	this->hideOptions = hideOptions;
 
 	m_pLabel = new QLabel(title, this);
 	m_pRLabel = new RotatableLabel(title, this);
 	m_pExpandButton = new QPushButton(this);
 	m_pCloseButton = new QPushButton(this);
 
-	if (verticalOnHidden)
+	if (hideOptions == WidgetTitleBar::TitleBarOptions::VerticalOnHidden)
 	{
-		m_pMainHLayout = new QHBoxLayout(this);
-
-		m_pMainHLayout->addWidget(m_pLabel);
-		m_pMainHLayout->addWidget(m_pExpandButton);
-		m_pMainHLayout->addWidget(m_pCloseButton);
-
-		m_pRLabel->hide();
+		setHorizontalLayout();
 	}
-	else
+	else if(hideOptions == WidgetTitleBar::TitleBarOptions::HorizontalOnHidden)
 	{
-		m_pMainVLayout = new QVBoxLayout(this);
-
-		m_pMainVLayout->addWidget(m_pRLabel);
-		m_pMainVLayout->addWidget(m_pExpandButton);
-		m_pMainVLayout->addWidget(m_pCloseButton);
-
-		m_pLabel->hide();
+		setVerticalLayout();
 	}
 
 	// add approriate icons for close and expand button
@@ -55,7 +45,14 @@ void WidgetTitleBar::expandButtonTriggered()
 	m_pCloseButton->show();
 	m_pExpandButton->hide();
 
-	setHorizontalLayout(!verticalOnHidden);
+	if (hideOptions == WidgetTitleBar::TitleBarOptions::VerticalOnHidden)
+	{
+		setHorizontalLayout();
+	}
+	else if (hideOptions == WidgetTitleBar::TitleBarOptions::HorizontalOnHidden)
+	{
+		setVerticalLayout();
+	}
 
 	pDock->widget()->show();
 }
@@ -65,26 +62,31 @@ void WidgetTitleBar::closeButtonTriggered()
 	m_pCloseButton->hide();
 	m_pExpandButton->show();
 
-	setVerticalLayout(!verticalOnHidden);
+	if (hideOptions == WidgetTitleBar::TitleBarOptions::VerticalOnHidden)
+	{
+		setVerticalLayout();
+	}
+	else if (hideOptions == WidgetTitleBar::TitleBarOptions::HorizontalOnHidden)
+	{
+		setHorizontalLayout();
+	}
 
 	pDock->close();
 }
 
-void WidgetTitleBar::setHorizontalLayout(bool switched)
+void WidgetTitleBar::setHorizontalLayout()
 {
-	if (switched)
+
+	if (m_pMainVLayout != nullptr)
 	{
-		setVerticalLayout(!switched);
-		return;
+		// Removes the widgets and destroys v layout
+		m_pMainVLayout->removeWidget(m_pRLabel);
+		m_pMainVLayout->removeWidget(m_pCloseButton);
+		m_pMainVLayout->removeWidget(m_pExpandButton);
+
+		delete m_pMainVLayout;
+		m_pMainVLayout = nullptr;
 	}
-
-	// Removes the widgets and destroys v layout
-	m_pMainVLayout->removeWidget(m_pRLabel);
-	m_pMainVLayout->removeWidget(m_pCloseButton);
-	m_pMainVLayout->removeWidget(m_pExpandButton);
-
-	delete m_pMainVLayout;
-	m_pMainVLayout = nullptr;
 
 	// Initializes and adds widgets to h layout
 	m_pMainHLayout = new QHBoxLayout(this);
@@ -98,21 +100,19 @@ void WidgetTitleBar::setHorizontalLayout(bool switched)
 	pDock->setFeatures(pDock->features() & ~QDockWidget::DockWidgetVerticalTitleBar);
 }
 
-void WidgetTitleBar::setVerticalLayout(bool switched)
+void WidgetTitleBar::setVerticalLayout()
 {
-	if (switched)
+
+	if (m_pMainHLayout != nullptr)
 	{
-		setHorizontalLayout(!switched);
-		return;
+		// Removes the widgets and destroys h layout
+		m_pMainHLayout->removeWidget(m_pLabel);
+		m_pMainHLayout->removeWidget(m_pCloseButton);
+		m_pMainHLayout->removeWidget(m_pExpandButton);
+
+		delete m_pMainHLayout;
+		m_pMainHLayout = nullptr;
 	}
-
-	// Removes the widgets and destroys h layout
-	m_pMainHLayout->removeWidget(m_pLabel);
-	m_pMainHLayout->removeWidget(m_pCloseButton);
-	m_pMainHLayout->removeWidget(m_pExpandButton);
-
-	delete m_pMainHLayout;
-	m_pMainHLayout = nullptr;
 
 	// Initializes and adds widgets to v layout
 	m_pMainVLayout = new QVBoxLayout(this);

--- a/lcUI/widgets/widgettitlebar.cpp
+++ b/lcUI/widgets/widgettitlebar.cpp
@@ -5,21 +5,33 @@ using namespace lc;
 using namespace lc::ui;
 using namespace lc::ui::widgets;
 
-WidgetTitleBar::WidgetTitleBar(const QString& title, QDockWidget* parent)
+WidgetTitleBar::WidgetTitleBar(const QString& title, QDockWidget* parent, bool verticalOnHidden)
 	: QWidget(parent)
 {
 	pDock = parent;
 
-	m_pMainHLayout = new QHBoxLayout(this);
+	this->verticalOnHidden = verticalOnHidden;
 
 	m_pLabel = new QLabel(title, this);
-	m_pMainHLayout->addWidget(m_pLabel);
-
 	m_pExpandButton = new QPushButton(this);
 	m_pCloseButton = new QPushButton(this);
 
-	m_pMainHLayout->addWidget(m_pExpandButton);
-	m_pMainHLayout->addWidget(m_pCloseButton);
+	if (verticalOnHidden)
+	{
+		m_pMainHLayout = new QHBoxLayout(this);
+
+		m_pMainHLayout->addWidget(m_pLabel);
+		m_pMainHLayout->addWidget(m_pExpandButton);
+		m_pMainHLayout->addWidget(m_pCloseButton);
+	}
+	else
+	{
+		m_pMainVLayout = new QVBoxLayout(this);
+
+		m_pMainVLayout->addWidget(m_pLabel);
+		m_pMainVLayout->addWidget(m_pExpandButton);
+		m_pMainVLayout->addWidget(m_pCloseButton);
+	}
 
 	QIcon icon1 = pDock->style()->standardIcon(QStyle::SP_TitleBarMaxButton, 0, pDock);
 	QIcon icon2 = pDock->style()->standardIcon(QStyle::SP_TitleBarCloseButton, 0, pDock);
@@ -38,7 +50,7 @@ void WidgetTitleBar::expandButtonTriggered()
 	m_pCloseButton->show();
 	m_pExpandButton->hide();
 
-	setHorizontalLayout();
+	setHorizontalLayout(!verticalOnHidden);
 
 	pDock->widget()->show();
 	pDock->setFeatures(pDock->features() & ~QDockWidget::DockWidgetVerticalTitleBar);
@@ -49,17 +61,24 @@ void WidgetTitleBar::closeButtonTriggered()
 	m_pCloseButton->hide();
 	m_pExpandButton->show();
 
-	setVerticalLayout();
+	setVerticalLayout(!verticalOnHidden);
 	pDock->close();
 }
 
-void WidgetTitleBar::setHorizontalLayout()
+void WidgetTitleBar::setHorizontalLayout(bool switched)
 {
+	if (switched)
+	{
+		setVerticalLayout(!switched);
+		return;
+	}
+
 	m_pMainVLayout->removeWidget(m_pLabel);
 	m_pMainVLayout->removeWidget(m_pCloseButton);
 	m_pMainVLayout->removeWidget(m_pExpandButton);
 
 	delete m_pMainVLayout;
+	m_pMainVLayout = nullptr;
 
 	m_pMainHLayout = new QHBoxLayout(this);
 	m_pMainHLayout->addWidget(m_pLabel);
@@ -67,13 +86,20 @@ void WidgetTitleBar::setHorizontalLayout()
 	m_pMainHLayout->addWidget(m_pExpandButton);
 }
 
-void WidgetTitleBar::setVerticalLayout()
+void WidgetTitleBar::setVerticalLayout(bool switched)
 {
+	if (switched)
+	{
+		setHorizontalLayout(!switched);
+		return;
+	}
+
 	m_pMainHLayout->removeWidget(m_pLabel);
 	m_pMainHLayout->removeWidget(m_pCloseButton);
 	m_pMainHLayout->removeWidget(m_pExpandButton);
 
 	delete m_pMainHLayout;
+	m_pMainHLayout = nullptr;
 
 	m_pMainVLayout = new QVBoxLayout(this);
 	m_pMainVLayout->addWidget(m_pLabel);

--- a/lcUI/widgets/widgettitlebar.cpp
+++ b/lcUI/widgets/widgettitlebar.cpp
@@ -29,9 +29,6 @@ WidgetTitleBar::WidgetTitleBar(const QString& title, QDockWidget* parent)
 
 	m_pExpandButton->hide();
 
-	Layers* parentObj = (Layers*)parent;
-
-	connect(m_pExpandButton, SIGNAL(clicked()), parentObj, SLOT(showWidget()));
 	connect(m_pExpandButton, SIGNAL(clicked()), this, SLOT(expandButtonTriggered()));
 	connect(m_pCloseButton, SIGNAL(clicked()), this, SLOT(closeButtonTriggered()));
 }
@@ -42,6 +39,9 @@ void WidgetTitleBar::expandButtonTriggered()
 	m_pExpandButton->hide();
 
 	setHorizontalLayout();
+
+	pDock->widget()->show();
+	pDock->setFeatures(pDock->features() & ~QDockWidget::DockWidgetVerticalTitleBar);
 }
 
 void WidgetTitleBar::closeButtonTriggered()

--- a/lcUI/widgets/widgettitlebar.cpp
+++ b/lcUI/widgets/widgettitlebar.cpp
@@ -76,7 +76,6 @@ void WidgetTitleBar::closeButtonTriggered()
 
 void WidgetTitleBar::setHorizontalLayout()
 {
-
 	if (m_pMainVLayout != nullptr)
 	{
 		// Removes the widgets and destroys v layout
@@ -102,7 +101,6 @@ void WidgetTitleBar::setHorizontalLayout()
 
 void WidgetTitleBar::setVerticalLayout()
 {
-
 	if (m_pMainHLayout != nullptr)
 	{
 		// Removes the widgets and destroys h layout

--- a/lcUI/widgets/widgettitlebar.h
+++ b/lcUI/widgets/widgettitlebar.h
@@ -17,7 +17,7 @@ namespace lc {
 				Q_OBJECT
 
 			public:
-				WidgetTitleBar(const QString& title, QDockWidget* parent);
+				WidgetTitleBar(const QString& title, QDockWidget* parent, bool verticalOnHidden);
 			protected slots:
 				void expandButtonTriggered();
 				void closeButtonTriggered();
@@ -29,8 +29,9 @@ namespace lc {
 				QPushButton* m_pExpandButton;
 				QPushButton* m_pCloseButton;
 				QStackedWidget* stackedWidget;
-				void setHorizontalLayout();
-				void setVerticalLayout();
+				bool verticalOnHidden;
+				void setHorizontalLayout(bool switched);
+				void setVerticalLayout(bool switched);
 			};
 		}
 	}

--- a/lcUI/widgets/widgettitlebar.h
+++ b/lcUI/widgets/widgettitlebar.h
@@ -29,6 +29,8 @@ namespace lc {
 				QPushButton* m_pExpandButton;
 				QPushButton* m_pCloseButton;
 				QStackedWidget* stackedWidget;
+				void setHorizontalLayout();
+				void setVerticalLayout();
 			};
 		}
 	}

--- a/lcUI/widgets/widgettitlebar.h
+++ b/lcUI/widgets/widgettitlebar.h
@@ -74,12 +74,19 @@ namespace lc {
 			 */
 			class WidgetTitleBar : public QWidget {
 				Q_OBJECT
-
+	
+			public:
+				enum class TitleBarOptions {
+					VerticalOnHidden,
+					HorizontalOnHidden
+				};
 			public:
 				/**
 				 * @params title of widget, parent, boolean for title bar to be vertical on hidden
 				 */
-				WidgetTitleBar(const QString& title, QDockWidget* parent, bool verticalOnHidden);
+				WidgetTitleBar( const QString& title,
+								QDockWidget* parent,
+								const TitleBarOptions hideOptions);
 			protected slots:
 				void expandButtonTriggered();
 				void closeButtonTriggered();
@@ -97,11 +104,12 @@ namespace lc {
 				QPushButton* m_pExpandButton;
 				QPushButton* m_pCloseButton;
 
-				bool verticalOnHidden;
+				// enums for hide options
+				TitleBarOptions hideOptions;
 
-				// switched - calls the other layout function
-				void setHorizontalLayout(bool switched);
-				void setVerticalLayout(bool switched);
+				// functions to switch to horizontal or vertical layouts
+				void setHorizontalLayout();
+				void setVerticalLayout();
 			};
 		}
 	}

--- a/lcUI/widgets/widgettitlebar.h
+++ b/lcUI/widgets/widgettitlebar.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QDockWidget>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QStackedWidget>
+
+namespace lc {
+	namespace ui {
+		namespace widgets {
+			/**
+			 * \brief Widget which shows a list of layers
+			 */
+			class WidgetTitleBar : public QWidget {
+				Q_OBJECT
+
+			public:
+				WidgetTitleBar(const QString& title, QDockWidget* parent);
+			protected slots:
+				void expandButtonTriggered();
+				void closeButtonTriggered();
+			private:
+				QDockWidget* pDock;
+				QVBoxLayout* m_pMainVLayout;
+				QHBoxLayout* m_pMainHLayout;
+				QLabel* m_pLabel;
+				QPushButton* m_pExpandButton;
+				QPushButton* m_pCloseButton;
+				QStackedWidget* stackedWidget;
+			};
+		}
+	}
+}

--- a/lcUI/widgets/widgettitlebar.h
+++ b/lcUI/widgets/widgettitlebar.h
@@ -6,10 +6,59 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QStackedWidget>
+#include <QStylePainter>
+#include<iostream>
 
 namespace lc {
 	namespace ui {
 		namespace widgets {
+
+			class RotatableLabel : public QLabel
+			{
+			Q_OBJECT
+
+			public:
+				explicit RotatableLabel(QWidget* parent = 0)
+					:
+					QLabel(parent),
+					angle(90)
+				{}
+				explicit RotatableLabel(const QString& text, QWidget* parent = 0)
+					:
+					QLabel(text, parent),
+					angle(90)
+				{}
+				void SetRotateAngle(float rot)
+				{
+					angle = rot;
+				}
+
+			protected:
+				void paintEvent(QPaintEvent* event)
+				{
+					QPainter painter(this);
+					painter.setPen(Qt::black);
+					painter.setBrush(Qt::Dense1Pattern);
+
+					painter.rotate(angle);
+						
+					// 5,-5
+					painter.drawText(0,0, text());
+				}
+				QSize RotatableLabel::minimumSizeHint() const
+				{
+					QSize s = QLabel::minimumSizeHint();
+					return QSize(s.height(), s.width());
+				}
+
+				QSize RotatableLabel::sizeHint() const
+				{
+					QSize s = QLabel::sizeHint();
+					return QSize(s.height(), s.width());
+				}
+			private:
+				float angle;
+			};
 			/**
 			 * \brief Widget which shows a list of layers
 			 */
@@ -25,6 +74,7 @@ namespace lc {
 				QDockWidget* pDock;
 				QVBoxLayout* m_pMainVLayout;
 				QHBoxLayout* m_pMainHLayout;
+				RotatableLabel* m_pRLabel;
 				QLabel* m_pLabel;
 				QPushButton* m_pExpandButton;
 				QPushButton* m_pCloseButton;

--- a/lcUI/widgets/widgettitlebar.h
+++ b/lcUI/widgets/widgettitlebar.h
@@ -13,6 +13,9 @@ namespace lc {
 	namespace ui {
 		namespace widgets {
 
+			/**
+			 * @brief RotatableLabel (by default rotates by 90)
+			 */
 			class RotatableLabel : public QLabel
 			{
 			Q_OBJECT
@@ -21,12 +24,14 @@ namespace lc {
 				explicit RotatableLabel(QWidget* parent = 0)
 					:
 					QLabel(parent),
-					angle(90)
+					angle(90),
+					qfm(QFont("times", 16))
 				{}
 				explicit RotatableLabel(const QString& text, QWidget* parent = 0)
 					:
 					QLabel(text, parent),
-					angle(90)
+					angle(90),
+					qfm(QFont("times", 16))
 				{}
 				void SetRotateAngle(float rot)
 				{
@@ -42,44 +47,59 @@ namespace lc {
 
 					painter.rotate(angle);
 						
-					// 5,-5
-					painter.drawText(0,0, text());
+					// hardcoded to 10 and -10, TODO think of a way to dynamically get vallues
+					painter.drawText(10,-10, text());
 				}
 				QSize RotatableLabel::minimumSizeHint() const
 				{
-					QSize s = QLabel::minimumSizeHint();
-					return QSize(s.height(), s.width());
+					return QSize(qfm.height(), qfm.horizontalAdvance(text()));
 				}
 
 				QSize RotatableLabel::sizeHint() const
 				{
-					QSize s = QLabel::sizeHint();
-					return QSize(s.height(), s.width());
+					return QSize(qfm.height(), qfm.horizontalAdvance(text()));
 				}
 			private:
 				float angle;
+				// QFontMetrics allows greater control plus fixed a bug of some
+				// of the text being covered by the button
+				QFontMetrics qfm;
 			};
+
 			/**
-			 * \brief Widget which shows a list of layers
+			 * @brief Custom widget title bar to replace default one
+			 *
+			 * Requires parent widget to override closeEvent and ignore event to stop
+			 * the widget from closing (see layers.cpp for example)
 			 */
 			class WidgetTitleBar : public QWidget {
 				Q_OBJECT
 
 			public:
+				/**
+				 * @params title of widget, parent, boolean for title bar to be vertical on hidden
+				 */
 				WidgetTitleBar(const QString& title, QDockWidget* parent, bool verticalOnHidden);
 			protected slots:
 				void expandButtonTriggered();
 				void closeButtonTriggered();
 			private:
 				QDockWidget* pDock;
+
 				QVBoxLayout* m_pMainVLayout;
 				QHBoxLayout* m_pMainHLayout;
+
+				// RotatableLabel for vertical text
 				RotatableLabel* m_pRLabel;
+				// Normal Qlabel for horizontal text
 				QLabel* m_pLabel;
+
 				QPushButton* m_pExpandButton;
 				QPushButton* m_pCloseButton;
-				QStackedWidget* stackedWidget;
+
 				bool verticalOnHidden;
+
+				// switched - calls the other layout function
 				void setHorizontalLayout(bool switched);
 				void setVerticalLayout(bool switched);
 			};

--- a/lcUI/widgets/widgettitlebar.h
+++ b/lcUI/widgets/widgettitlebar.h
@@ -51,12 +51,12 @@ namespace lc {
 				}
 				QSize minimumSizeHint() const
 				{
-					return QSize(qfm.height(), qfm.horizontalAdvance(text()));
+					return QSize(qfm.height(), qfm.boundingRect(text()).width());
 				}
 
 				QSize sizeHint() const
 				{
-					return QSize(qfm.height(), qfm.horizontalAdvance(text()));
+					return QSize(qfm.height(), qfm.boundingRect(text()).width());
 				}
 			private:
 				float angle;

--- a/lcUI/widgets/widgettitlebar.h
+++ b/lcUI/widgets/widgettitlebar.h
@@ -7,7 +7,6 @@
 #include <QPushButton>
 #include <QStackedWidget>
 #include <QStylePainter>
-#include<iostream>
 
 namespace lc {
 	namespace ui {
@@ -50,12 +49,12 @@ namespace lc {
 					// hardcoded to 10 and -10, TODO think of a way to dynamically get vallues
 					painter.drawText(10,-10, text());
 				}
-				QSize RotatableLabel::minimumSizeHint() const
+				QSize minimumSizeHint() const
 				{
 					return QSize(qfm.height(), qfm.horizontalAdvance(text()));
 				}
 
-				QSize RotatableLabel::sizeHint() const
+				QSize sizeHint() const
 				{
 					return QSize(qfm.height(), qfm.horizontalAdvance(text()));
 				}

--- a/lcUI/widgets/widgettitlebar.h
+++ b/lcUI/widgets/widgettitlebar.h
@@ -80,6 +80,7 @@ namespace lc {
 					VerticalOnHidden,
 					HorizontalOnHidden
 				};
+
 			public:
 				/**
 				 * @params title of widget, parent, boolean for title bar to be vertical on hidden
@@ -90,6 +91,7 @@ namespace lc {
 			protected slots:
 				void expandButtonTriggered();
 				void closeButtonTriggered();
+
 			private:
 				QDockWidget* pDock;
 


### PR DESCRIPTION
Added custom titlebar class that allows you to hide the widget .

1) WidgetTitlebar is set as the default titlebar for the cli command, layers and toolbar widgets.
2) widgettitlebar also contains rotatablelabel class to allow vertical text when widgets are hidden.
3) clicommand,layers and toolbar widgets override the closeEvent function to hide the widget instead of closing it.