### PR TITLE
3 minor bug fixes

### DIFF
--- a/lcUI/cadmdichild.cpp
+++ b/lcUI/cadmdichild.cpp
@@ -133,6 +133,11 @@ void CadMdiChild::saveAsFile() {
 
     auto file = QFileDialog::getSaveFileName(nullptr, "Save file", "", filterList, &selectedFilter);
 
+    if (file.isEmpty())
+    {
+        return;
+    }
+
     auto selectedType = selectedFilter.toStdString();
     //Removing extension part
     std::size_t fpos = selectedType.rfind("(*");

--- a/lcUILua/createActions/lwpolylineoperations.lua
+++ b/lcUILua/createActions/lwpolylineoperations.lua
@@ -56,8 +56,10 @@ function LWPolylineOperations:close()
     end
 
 	if(self.creatingPolyspline == nil) then
-        self.creatingPolyspline = true
-        self:createEntity()
+        if(#self.builder:getVertices() > 1) then
+            self.creatingPolyspline = true
+            self:createEntity()
+        end
         CreateOperations.close(self)
     end
 end

--- a/persistence/libdxfrw/dxfimpl.cpp
+++ b/persistence/libdxfrw/dxfimpl.cpp
@@ -1289,6 +1289,12 @@ void DXFimpl::writeEntity(const lc::entity::CADEntity_CSPtr& entity) {
          writeInsert(insert);
          return;
     }
+
+    auto spline = std::dynamic_pointer_cast<const lc::entity::Spline>(entity);
+    if (spline != nullptr) {
+        writeSpline(spline);
+        return;
+    }
 }
 
 void DXFimpl::writeBlockRecords() {


### PR DESCRIPTION
1) LWPolyline would crash on clicking on the lwpolyline button twice in the quick access bar or the menu. Reason for crash was that the polyline created during the first click was being built with zero vertices which was causing the crash.

2) Clicking cancel on the save as dialog would cause a crash, this was because the file was not checked for being empty.

3) Spline was not being saved. This was because of a missing condition in writeEntity function. (As of yet dxfrw can't save splines in dxf12 and above but it works for older versions.)