### PR TITLE
Fixed 2 command line bugs

### DIFF
--- a/lcUI/lua/qtbridge.cpp
+++ b/lcUI/lua/qtbridge.cpp
@@ -41,6 +41,7 @@ void addQtBaseBindings(lua_State *L) {
 		.addFunction("show", &QWidget::show)
 		.addFunction("showMaximized", &QWidget::showMaximized)
         .addFunction("setToolTip", &QWidget::setToolTip)
+        .addFunction("setFocus", static_cast<void (QWidget::*)()>(&QMainWindow::setFocus))
 	);
 
 	state["qt"]["QString"].setClass(kaguya::UserdataMetatable<QString>()

--- a/lcUI/widgets/clicommand.cpp
+++ b/lcUI/widgets/clicommand.cpp
@@ -197,6 +197,10 @@ void CliCommand::onKeyPressed(QKeyEvent *event) {
             }
             break;
 
+        case Qt::Key_Escape:
+            emit finishOperation();
+            break;
+
         default:
             ui->command->event(event);
             break;

--- a/lcUI/widgets/clicommand.h
+++ b/lcUI/widgets/clicommand.h
@@ -94,6 +94,8 @@ namespace lc {
 
                     void textEntered(QString text);
 
+                    void finishOperation();
+
                 private:
                     bool checkParam(const QString& command);
 

--- a/lcUILua/createActions/createOperations.lua
+++ b/lcUILua/createActions/createOperations.lua
@@ -86,7 +86,7 @@ function CreateOperations:close()
         luaInterface:triggerEvent('operationFinished', self.target_widget)
         self:removeTempEntity()
         self:unregisterEvents()
-        cli_get_text(0, false)
+        cli_get_text(self.target_widget, false)
         cli_command_active(self.target_widget, false)
         self.finished = true
     end

--- a/lcUILua/createActions/createOperations.lua
+++ b/lcUILua/createActions/createOperations.lua
@@ -86,6 +86,8 @@ function CreateOperations:close()
         luaInterface:triggerEvent('operationFinished', self.target_widget)
         self:removeTempEntity()
         self:unregisterEvents()
+        cli_get_text(0, false)
+        cli_command_active(self.target_widget, false)
         self.finished = true
     end
 end

--- a/lcUILua/ui/commandline.lua
+++ b/lcUILua/ui/commandline.lua
@@ -28,6 +28,11 @@ function cli_command_active(id, status)
     end
 end
 
+-- focus cli command
+function focusClicommand()
+    cliCommand:setFocus()
+end
+
 --Configure command line to return raw text
 function cli_get_text(id, getText)
     if cliCommands[id] ~= nil then
@@ -47,7 +52,7 @@ end
 
 --Create the command line and add it to the main window
 function add_commandline(mainWindow, id)
-    local cliCommand = lc.CliCommand(mainWindow)
+    cliCommand = lc.CliCommand(mainWindow)
     mainWindow:addDockWidget(8, cliCommand)
     cliCommands[id] = cliCommand
 

--- a/lcUILua/ui/commandline.lua
+++ b/lcUILua/ui/commandline.lua
@@ -104,8 +104,8 @@ end
 
 --Register every commands
 add_command("LINE", function(id) run_basic_operation(id, LineOperations) end)
-add_command("CIRCLE", function(id) run_basic_operation(id, CircleOperations) end)
-add_command("ARC", function(id) run_basic_operation(id, ArcOperations) end)
+add_command("CIRCLE", function(id) op = run_basic_operation(id, CircleOperations); op:_init_default()  end)
+add_command("ARC", function(id) op = run_basic_operation(id, ArcOperations); op:_init_default() end)
 add_command("ELLIPSE", function(id) run_basic_operation(id, EllipseOperations) end)
 add_command("ARCELLIPSE", function(id) run_basic_operation(id, EllipseOperations, true) end)
 add_command("DIMALIGNED", function(id) run_basic_operation(id, DimAlignedOperations) end)

--- a/lcUILua/ui/commandline.lua
+++ b/lcUILua/ui/commandline.lua
@@ -29,8 +29,8 @@ function cli_command_active(id, status)
 end
 
 -- focus cli command
-function focusClicommand()
-    cliCommand:setFocus()
+function focusClicommand(id)
+    cliCommands[id]:setFocus()
 end
 
 --Configure command line to return raw text
@@ -52,7 +52,7 @@ end
 
 --Create the command line and add it to the main window
 function add_commandline(mainWindow, id)
-    cliCommand = lc.CliCommand(mainWindow)
+    local cliCommand = lc.CliCommand(mainWindow)
     mainWindow:addDockWidget(8, cliCommand)
     cliCommands[id] = cliCommand
 
@@ -104,8 +104,8 @@ end
 
 --Register every commands
 add_command("LINE", function(id) run_basic_operation(id, LineOperations) end)
-add_command("CIRCLE", function(id) op = run_basic_operation(id, CircleOperations); op:_init_default()  end)
-add_command("ARC", function(id) op = run_basic_operation(id, ArcOperations); op:_init_default() end)
+add_command("CIRCLE", function(id) run_basic_operation(id, CircleOperations) end)
+add_command("ARC", function(id) run_basic_operation(id, ArcOperations) end)
 add_command("ELLIPSE", function(id) run_basic_operation(id, EllipseOperations) end)
 add_command("ARCELLIPSE", function(id) run_basic_operation(id, EllipseOperations, true) end)
 add_command("DIMALIGNED", function(id) run_basic_operation(id, DimAlignedOperations) end)

--- a/lcUILua/ui/commandline.lua
+++ b/lcUILua/ui/commandline.lua
@@ -58,6 +58,11 @@ function add_commandline(mainWindow, id)
 
     luaInterface:luaConnect(cliCommand, "commandEntered(QString)", function(...) command(id, ...) end)
 
+    luaInterface:luaConnect(cliCommand, "finishOperation()", function()
+        luaInterface:triggerEvent('operationFinished', 0)
+        luaInterface:triggerEvent('finishOperation', 0)
+    end)
+
     luaInterface:luaConnect(cliCommand, "coordinateEntered(lc::geo::Coordinate)", function(coordinate)
         luaInterface:triggerEvent('point', {
             position = coordinate,

--- a/lcUILua/ui/mainwindow.lua
+++ b/lcUILua/ui/mainwindow.lua
@@ -117,8 +117,8 @@ local function create_menu(mainWindow, widget, commandLine, id)
 
 	-- connect draw menu options
 	luaInterface:luaConnect(lineAction, "triggered(bool)", function() run_basic_operation(id, LineOperations) end)
-	luaInterface:luaConnect(circleAction, "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_default()  end)
-	luaInterface:luaConnect(arcAction, "triggered(bool)", function() op = run_basic_operation(id, ArcOperations); op:_init_3p() end)
+	luaInterface:luaConnect(circleAction, "triggered(bool)", function() run_basic_operation(id, CircleOperations) end)
+	luaInterface:luaConnect(arcAction, "triggered(bool)", function() run_basic_operation(id, ArcOperations) end)
 	luaInterface:luaConnect(ellipseAction, "triggered(bool)", function() run_basic_operation(id, EllipseOperations) end)
 	luaInterface:luaConnect(splineAction, "triggered(bool)", function() run_basic_operation(id, SplineOperations) end)
 	luaInterface:luaConnect(polylineAction, "triggered(bool)", function() create_lw_polyline(id) end)

--- a/lcUILua/ui/operations.lua
+++ b/lcUILua/ui/operations.lua
@@ -11,6 +11,10 @@ local function remove_operation_group(eventName, id)
     getWindow(id):viewer():setOperationActive(false)
 end
 
+function finish(eventName, id)
+    finish_operation(id)
+end
+
 --End the current operation, even if it's not finished
 function finish_operation(id)
     local op = luaInterface:operation(id);
@@ -32,6 +36,7 @@ local function create_cancel_button(id)
 end
 
 luaInterface:registerEvent('operationFinished', remove_operation_group)
+luaInterface:registerEvent('finishOperation', finish)
 
 --Every function corresponding to the buttons in the toolbar or commands in cli widget
 function run_basic_operation(id, operation, ...)

--- a/lcUILua/ui/operations.lua
+++ b/lcUILua/ui/operations.lua
@@ -39,17 +39,24 @@ luaInterface:registerEvent('operationFinished', remove_operation_group)
 luaInterface:registerEvent('finishOperation', finish)
 
 --Every function corresponding to the buttons in the toolbar or commands in cli widget
-function run_basic_operation(id, operation, ...)
-    focusClicommand()
+function run_basic_operation(id, operation, init_method, ...)
+    focusClicommand(id)
     finish_operation(id)
     create_cancel_button(id)
     luaInterface:setOperation(id, operation(id, ...))
 	op = luaInterface:operation(id)
+    if(init_method) then
+        op[init_method](op, ...)
+    else
+        if(op['_init_default'] ~= nil) then
+           op['_init_default'](op)
+        end
+    end
 	return op
 end
 
 function create_lw_polyline(id)
-    focusClicommand()
+    focusClicommand(id)
     finish_operation(id)
     create_cancel_button(id)
 

--- a/lcUILua/ui/operations.lua
+++ b/lcUILua/ui/operations.lua
@@ -35,6 +35,7 @@ luaInterface:registerEvent('operationFinished', remove_operation_group)
 
 --Every function corresponding to the buttons in the toolbar or commands in cli widget
 function run_basic_operation(id, operation, ...)
+    focusClicommand()
     finish_operation(id)
     create_cancel_button(id)
     luaInterface:setOperation(id, operation(id, ...))
@@ -43,6 +44,7 @@ function run_basic_operation(id, operation, ...)
 end
 
 function create_lw_polyline(id)
+    focusClicommand()
     finish_operation(id)
     create_cancel_button(id)
 

--- a/lcUILua/ui/toolbar.lua
+++ b/lcUILua/ui/toolbar.lua
@@ -62,11 +62,11 @@ function add_toolbar(mainWindow, id, linePatternSelect, lineWidthSelect, colorSe
 
     local circleButton = create_button("", ":/icons/circle.svg", "Circle")
     quickAccessTab:addWidget(creationGroup, circleButton, 1, 0, 1, 1)
-    luaInterface:luaConnect(circleButton, "pressed()", function() op = run_basic_operation(id, CircleOperations); op:_init_default()  end)
+    luaInterface:luaConnect(circleButton, "pressed()", function() run_basic_operation(id, CircleOperations) end)
 
     local arcButton = create_button("", ":/icons/arc.svg", "Arc")
     quickAccessTab:addWidget(creationGroup, arcButton, 0, 1, 1, 1)
-    luaInterface:luaConnect(arcButton, "pressed()", function() op = run_basic_operation(id, ArcOperations); op:_init_3p() end)
+    luaInterface:luaConnect(arcButton, "pressed()", function() run_basic_operation(id, ArcOperations) end)
 
     local spline = create_button("", ":/icons/spline.svg", "Spline")
     quickAccessTab:addWidget(creationGroup, spline, 2, 0, 1, 1)

--- a/lcUILua/ui/toolbar.lua
+++ b/lcUILua/ui/toolbar.lua
@@ -62,11 +62,11 @@ function add_toolbar(mainWindow, id, linePatternSelect, lineWidthSelect, colorSe
 
     local circleButton = create_button("", ":/icons/circle.svg", "Circle")
     quickAccessTab:addWidget(creationGroup, circleButton, 1, 0, 1, 1)
-    luaInterface:luaConnect(circleButton, "pressed()", function() run_basic_operation(id, CircleOperations) end)
+    luaInterface:luaConnect(circleButton, "pressed()", function() op = run_basic_operation(id, CircleOperations); op:_init_default()  end)
 
     local arcButton = create_button("", ":/icons/arc.svg", "Arc")
     quickAccessTab:addWidget(creationGroup, arcButton, 0, 1, 1, 1)
-    luaInterface:luaConnect(arcButton, "pressed()", function() run_basic_operation(id, ArcOperations) end)
+    luaInterface:luaConnect(arcButton, "pressed()", function() op = run_basic_operation(id, ArcOperations); op:_init_3p() end)
 
     local spline = create_button("", ":/icons/spline.svg", "Spline")
     quickAccessTab:addWidget(creationGroup, spline, 2, 0, 1, 1)


### PR DESCRIPTION
1) After selecting any create operation(eg. line,circle,lwpolyline etc), now able to type directly which was not possible before without clicking.

2) Clicking escape did not work before if no point was clicked or if the text field had been selected. Now clicking escape finishes the operation even in those cases.