### PR TITLE
Delete button gets disabled when only one layer is left

### DIFF
--- a/lcUI/widgets/layers.cpp
+++ b/lcUI/widgets/layers.cpp
@@ -123,9 +123,6 @@ void Layers::changeLayerName(lc::meta::Layer_CSPtr& layer, const std::string& na
 
 void Layers::createLayer(lc::meta::Layer_CSPtr layer) {
     if(_mdiChild != nullptr) {
-        QPushButton* deleteBut = this->findChild<QPushButton*>(QString("deleteButton"));
-        deleteBut->setEnabled(true);
-
         auto operation = std::make_shared<lc::operation::AddLayer>(_mdiChild->document(), layer);
         operation->execute();
     }
@@ -170,11 +167,15 @@ void Layers::updateLayerList() {
         emit layerChanged(layer);
     }
 
+    QPushButton* deleteBut = this->findChild<QPushButton*>(QString("deleteButton"));
     //check if only one layer is remaining, in which case disable button
-    if (model->rowCount(QModelIndex()) == 1)
+    if(model->rowCount(QModelIndex()) == 1)
     {
-        QPushButton* deleteBut = this->findChild<QPushButton*>(QString("deleteButton"));
         deleteBut->setEnabled(false);
+    }
+    else
+    {
+        deleteBut->setEnabled(true);
     }
 }
 

--- a/lcUI/widgets/layers.cpp
+++ b/lcUI/widgets/layers.cpp
@@ -2,7 +2,6 @@
 #include <QtWidgets/QMessageBox>
 #include "layers.h"
 #include "ui_layers.h"
-#include <iostream>
 
 using namespace lc;
 using namespace lc::ui;
@@ -124,11 +123,8 @@ void Layers::changeLayerName(lc::meta::Layer_CSPtr& layer, const std::string& na
 
 void Layers::createLayer(lc::meta::Layer_CSPtr layer) {
     if(_mdiChild != nullptr) {
-        if (model->rowCount(QModelIndex()) == 1)
-        {
-            QPushButton* deleteBut = this->findChild<QPushButton*>(QString("deleteButton"));
-            deleteBut->setEnabled(true);
-        }
+        QPushButton* deleteBut = this->findChild<QPushButton*>(QString("deleteButton"));
+        deleteBut->setEnabled(true);
 
         auto operation = std::make_shared<lc::operation::AddLayer>(_mdiChild->document(), layer);
         operation->execute();
@@ -190,7 +186,7 @@ void Layers::on_addLayerEvent(const lc::event::AddLayerEvent& event) {
 
 void Layers::on_removeLayerEvent(const lc::event::RemoveLayerEvent& event) {
     if(_mdiChild->activeLayer() == event.layer()) {
-        _mdiChild->setActiveLayer(_mdiChild->document()->layerByName("0"));
+        _mdiChild->setActiveLayer(model->layerAt(0));
     }
 
     updateLayerList();

--- a/lcUI/widgets/layers.cpp
+++ b/lcUI/widgets/layers.cpp
@@ -2,6 +2,7 @@
 #include <QtWidgets/QMessageBox>
 #include "layers.h"
 #include "ui_layers.h"
+#include <iostream>
 
 using namespace lc;
 using namespace lc::ui;
@@ -123,6 +124,12 @@ void Layers::changeLayerName(lc::meta::Layer_CSPtr& layer, const std::string& na
 
 void Layers::createLayer(lc::meta::Layer_CSPtr layer) {
     if(_mdiChild != nullptr) {
+        if (model->rowCount(QModelIndex()) == 1)
+        {
+            QPushButton* deleteBut = this->findChild<QPushButton*>(QString("deleteButton"));
+            deleteBut->setEnabled(true);
+        }
+
         auto operation = std::make_shared<lc::operation::AddLayer>(_mdiChild->document(), layer);
         operation->execute();
     }
@@ -165,6 +172,13 @@ void Layers::updateLayerList() {
         ui->layerList->selectRow(model->indexOf(layer));
 
         emit layerChanged(layer);
+    }
+
+    //check if only one layer is remaining, in which case disable button
+    if (model->rowCount(QModelIndex()) == 1)
+    {
+        QPushButton* deleteBut = this->findChild<QPushButton*>(QString("deleteButton"));
+        deleteBut->setEnabled(false);
     }
 }
 

--- a/lckernel/cad/operations/layerops.cpp
+++ b/lckernel/cad/operations/layerops.cpp
@@ -30,11 +30,6 @@ void AddLayer::redo() const {
 RemoveLayer::RemoveLayer(std::shared_ptr<storage::Document> document, meta::Layer_CSPtr layer) :
         DocumentOperation(std::move(document), "RemoveLayer"),
         _layer(std::move(layer)) {
-
-    if(_layer->name() == "0") {
-        throw std::runtime_error("Layer 0 cannot be removed");
-    }
-
 }
 
 void RemoveLayer::processInternal() {


### PR DESCRIPTION
Clicking delete for zeroth layer does not throw a runtime exception anymore and delete button get's disabled whenever one layer is left.