### PR TITLE
Added Circle tangent to three other circles and tangent to two circle feature

### DIFF
--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -192,23 +192,61 @@ function CircleOperations:CircleWith3Points(eventName, data)
     end
 end
 
+-- Depending on position of mouse cursor, return appropriate s1,s2 and s3 for circle with 3 tans
+function CircleOperations:getCircleWith3TansOptions(newPos)
+    if(self.initialMousePosition == nil) then
+        return 1,1,1
+    end
+
+    local base = lc.geo.Coordinate(self.initialMousePosition.x, 0)
+    local angle = self.initialMousePosition:angleBetween(base, newPos)
+
+    -- convert angle from range -pi to pi to 1 to 8
+    angle = angle + 3.14159265
+    angle = angle / (3.14159265 * 2)
+    angle = angle * 8
+
+    if(angle < 1) then
+        return 1,1,1
+    elseif(angle < 2) then
+        return -1,1,1
+    elseif(angle < 3) then
+        return 1,-1,1
+    elseif(angle < 4) then
+        return 1,1,-1
+    elseif(angle < 5) then
+        return -1,-1,1
+    elseif(angle < 6) then
+        return 1,-1,-1
+    elseif(angle < 7) then
+        return -1,1,-1
+    else
+        return -1,-1,-1
+    end
+end
+
 function CircleOperations:CircleWith3Tans(eventName, data)
     if(eventName == "mouseMove") then
         if(self.constructed3tan ~= true) then
             self.selection = getWindow(self.target_widget):selection()
+            self.initialMousePosition = data["position"]
             if(#self.selection == 3) then
                 local success = self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, 1, 1)
                 if success == false then
                     message("Entities selected MUST be circles", self.target_widget)
+                    finish_operation(self.target_widget)
                 else
                     self:refreshTempEntity()
                     self.constructed3tan = true
+                    message("Move mouse around to cycle through different circles", self.target_widget)
                 end
             else
                 message("THREE circle entities should be selected", self.target_widget)
+                finish_operation(self.target_widget)
             end
         else
-            self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, -1, 1)
+            local s1,s2,s3 = self:getCircleWith3TansOptions(data["position"])
+            self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], s1, s2, s3)
             self:refreshTempEntity()
         end
     elseif(eventName == "point") then

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -226,9 +226,7 @@ function CircleOperations:getCircleWith3TansOptions(newPos)
 end
 
 function CircleOperations:getIndexForCircleWithTwoTan(newPos)
-    local base = lc.geo.Coordinate(self.initialMousePosition.x, 0)
-    local angle = self.initialMousePosition:angleBetween(base, newPos)
-
+    local angle = self.twocirclecenters[1]:angleBetween(self.twocirclecenters[2], newPos)
     if(angle > 0) then
         return 0
     else
@@ -282,13 +280,17 @@ function CircleOperations:CircleWith2Tans(eventName, data)
                     self:refreshTempEntity()
                 end
                 message("Move mouse for radius, and around to cycle through different circles", self.target_widget)
+                -- get center of two circles from circlebuilder and set center between the two circles
+                self.twocirclecenters = self.builder:twoTanCircleCenters()
+                self.centerbetweentwocircles = self.twocirclecenters[1]:add(self.twocirclecenters[2])
+                self.centerbetweentwocircles = self.centerbetweentwocircles:multiply(0.5)
                 self.constructed2tan = true
             else
                 message("TWO circle entities should be selected", self.target_widget)
                 finish_operation(self.target_widget)
             end
         else
-            local radius = self.initialMousePosition:distanceTo(data["position"])
+            local radius = self.centerbetweentwocircles:distanceTo(data["position"])
             local index = self:getIndexForCircleWithTwoTan(data["position"])
             self.builder:twoTanConstructor(self.selection[1], self.selection[2], -1, -1, radius, index)
             self:refreshTempEntity()

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -193,22 +193,27 @@ function CircleOperations:CircleWith3Points(eventName, data)
 end
 
 function CircleOperations:CircleWith3Tans(eventName, data)
-    self.selection = getWindow(self.target_widget):selection()
-    message(tostring(#self.selection) .. " items selected", self.target_widget)
-
-    -- assuming selected entities are circle for now
-    if(#self.selection == 3) then
-        local success = self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, 1, 1)
-        if success == false then
-            message("Entities selected MUST be circles", self.target_widget)
+    if(eventName == "mouseMove") then
+        if(self.constructed3tan ~= true) then
+            self.selection = getWindow(self.target_widget):selection()
+            if(#self.selection == 3) then
+                local success = self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, 1, 1)
+                if success == false then
+                    message("Entities selected MUST be circles", self.target_widget)
+                else
+                    self:refreshTempEntity()
+                    self.constructed3tan = true
+                end
+            else
+                message("THREE circle entities should be selected", self.target_widget)
+            end
         else
-            self:createEntity()
+            self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, -1, 1)
+            self:refreshTempEntity()
         end
-    else
-        message("THREE circle entities should be selected", self.target_widget)
+    elseif(eventName == "point") then
+        self:createEntity()
     end
-
-    finish_operation(self.target_widget)
 end
 
 function CircleOperations:CircleWith2Tans(eventName, data)

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -200,7 +200,8 @@ function CircleOperations:CircleWith3Tans(eventName, data)
     -- assuming selected entities are circle for now
     -- see page http://mathworld.wolfram.com/ApolloniusProblem.html for calculation
     if(#self.selection == 3) then
-        self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3])
+        self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, 1, 1)
+        self:createEntity()
     end
 
     finish_operation(self.target_widget)

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -275,6 +275,9 @@ function CircleOperations:CircleWith2Tans(eventName, data)
                 if (success == -2) then
                     message("Entities selected MUST be circles", self.target_widget)
                     finish_operation(self.target_widget)
+                elseif (success == -3) then
+                    message("Circle cannot be created for selected circle entities (one circle should not be contained inside another)", self.target_widget)
+                    finish_operation(self.target_widget)
                 elseif (success == 0) then
                     self:refreshTempEntity()
                 end

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -225,6 +225,17 @@ function CircleOperations:getCircleWith3TansOptions(newPos)
     end
 end
 
+function CircleOperations:getIndexForCircleWithTwoTan(newPos)
+    local base = lc.geo.Coordinate(self.initialMousePosition.x, 0)
+    local angle = self.initialMousePosition:angleBetween(base, newPos)
+
+    if(angle > 0) then
+        return 0
+    else
+        return 1
+    end
+end
+
 function CircleOperations:CircleWith3Tans(eventName, data)
     if(eventName == "mouseMove") then
         if(self.constructed3tan ~= true) then
@@ -255,11 +266,33 @@ function CircleOperations:CircleWith3Tans(eventName, data)
 end
 
 function CircleOperations:CircleWith2Tans(eventName, data)
-    message("TODO:2 Tan Circle.",self.target_widget) -- This function requires picking or selecting CIRCLE or ARC entities. Once picking or selcting of objects starts working this function can be coded.
-    self.selection = getWindow(self.target_widget):selection()
-    -- -1,-1
-    local success = self.builder:twoTanConstructor(self.selection[1], self.selection[2], -1, -1, 50, 0)
-    self:createEntity()
+    if(eventName == "mouseMove") then
+        if(self.constructed2tan ~= true) then
+            self.selection = getWindow(self.target_widget):selection()
+            self.initialMousePosition = data["position"]
+            if(#self.selection == 2) then
+                local success = self.builder:twoTanConstructor(self.selection[1], self.selection[2], -1, -1, 50, 0)
+                if (success == -2) then
+                    message("Entities selected MUST be circles", self.target_widget)
+                    finish_operation(self.target_widget)
+                elseif (success == 0) then
+                    self:refreshTempEntity()
+                end
+                message("Move mouse for radius, and around to cycle through different circles", self.target_widget)
+                self.constructed2tan = true
+            else
+                message("TWO circle entities should be selected", self.target_widget)
+                finish_operation(self.target_widget)
+            end
+        else
+            local radius = self.initialMousePosition:distanceTo(data["position"])
+            local index = self:getIndexForCircleWithTwoTan(data["position"])
+            self.builder:twoTanConstructor(self.selection[1], self.selection[2], -1, -1, radius, index)
+            self:refreshTempEntity()
+        end
+    elseif(eventName == "point") then
+        self:createEntity()
+    end
 end
 
 function CircleOperations:Circumcenter(Point1,Point2,Point3)

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -193,15 +193,19 @@ function CircleOperations:CircleWith3Points(eventName, data)
 end
 
 function CircleOperations:CircleWith3Tans(eventName, data)
-    message("TODO:3 Tan Circle.",self.target_widget) -- This function requires picking or selecting CIRCLE or ARC entities. Once picking or selcting of objects starts working this function can be coded.
     self.selection = getWindow(self.target_widget):selection()
     message(tostring(#self.selection) .. " items selected", self.target_widget)
 
     -- assuming selected entities are circle for now
-    -- see page http://mathworld.wolfram.com/ApolloniusProblem.html for calculation
     if(#self.selection == 3) then
-        self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, 1, 1)
-        self:createEntity()
+        local success = self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, 1, 1)
+        if success == false then
+            message("Entities selected MUST be circles", self.target_widget)
+        else
+            self:createEntity()
+        end
+    else
+        message("THREE circle entities should be selected", self.target_widget)
     end
 
     finish_operation(self.target_widget)

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -194,6 +194,15 @@ end
 
 function CircleOperations:CircleWith3Tans(eventName, data)
     message("TODO:3 Tan Circle.",self.target_widget) -- This function requires picking or selecting CIRCLE or ARC entities. Once picking or selcting of objects starts working this function can be coded.
+    self.selection = getWindow(self.target_widget):selection()
+    message(tostring(#self.selection) .. " items selected", self.target_widget)
+
+    -- assuming selected entities are circle for now
+    -- see page http://mathworld.wolfram.com/ApolloniusProblem.html for calculation
+    if(#self.selection == 3) then
+        self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3])
+    end
+
     finish_operation(self.target_widget)
 end
 

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -256,7 +256,10 @@ end
 
 function CircleOperations:CircleWith2Tans(eventName, data)
     message("TODO:2 Tan Circle.",self.target_widget) -- This function requires picking or selecting CIRCLE or ARC entities. Once picking or selcting of objects starts working this function can be coded.
-    finish_operation(self.target_widget)
+    self.selection = getWindow(self.target_widget):selection()
+    -- -1,-1
+    local success = self.builder:twoTanConstructor(self.selection[1], self.selection[2], -1, -1, 50, 0)
+    self:createEntity()
 end
 
 function CircleOperations:Circumcenter(Point1,Point2,Point3)

--- a/lcUILua/ui/mainwindow.lua
+++ b/lcUILua/ui/mainwindow.lua
@@ -134,8 +134,8 @@ local function connect_buttons(mainWindow, id)
 	luaInterface:luaConnect(mainWindow:findChild("actionCenter_Diameter"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_cd() end)
 	luaInterface:luaConnect(mainWindow:findChild("action2_Point_Circle"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_2p() end)
 	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Circle_2"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_3p() end)
-	luaInterface:luaConnect(mainWindow:findChild("actionTan_Tan_Radius"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_3t() end)
-	luaInterface:luaConnect(mainWindow:findChild("actionTan_Tan_Tan"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_2t() end)
+	luaInterface:luaConnect(mainWindow:findChild("actionTan_Tan_Radius"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_2t() end)
+	luaInterface:luaConnect(mainWindow:findChild("actionTan_Tan_Tan"), "triggered(bool)", function() op = run_basic_operation(id, CircleOperations); op:_init_3t() end)
 
 	-- arc
 	luaInterface:luaConnect(mainWindow:findChild("action3_Point_Arc"), "triggered(bool)", function() op = run_basic_operation(id, ArcOperations); op:_init_3p() end)

--- a/lcadluascript/bridge/lc_builder.cpp
+++ b/lcadluascript/bridge/lc_builder.cpp
@@ -89,6 +89,7 @@ void import_lc_builder_namespace(kaguya::State& state) {
         .addFunction("setCenter", &lc::builder::CircleBuilder::setCenter)
         .addFunction("setRadius", &lc::builder::CircleBuilder::setRadius)
         .addFunction("threeTanConstructor", &lc::builder::CircleBuilder::threeTanConstructor)
+        .addFunction("twoTanConstructor", &lc::builder::CircleBuilder::twoTanConstructor)
     );
 
 

--- a/lcadluascript/bridge/lc_builder.cpp
+++ b/lcadluascript/bridge/lc_builder.cpp
@@ -88,6 +88,7 @@ void import_lc_builder_namespace(kaguya::State& state) {
         .addFunction("radius", &lc::builder::CircleBuilder::radius)
         .addFunction("setCenter", &lc::builder::CircleBuilder::setCenter)
         .addFunction("setRadius", &lc::builder::CircleBuilder::setRadius)
+        .addFunction("threeTanConstructor", &lc::builder::CircleBuilder::threeTanConstructor)
     );
 
 

--- a/lcadluascript/bridge/lc_builder.cpp
+++ b/lcadluascript/bridge/lc_builder.cpp
@@ -90,6 +90,7 @@ void import_lc_builder_namespace(kaguya::State& state) {
         .addFunction("setRadius", &lc::builder::CircleBuilder::setRadius)
         .addFunction("threeTanConstructor", &lc::builder::CircleBuilder::threeTanConstructor)
         .addFunction("twoTanConstructor", &lc::builder::CircleBuilder::twoTanConstructor)
+        .addFunction("twoTanCircleCenters", &lc::builder::CircleBuilder::twoTanCircleCenters)
     );
 
 

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -94,14 +94,14 @@ bool lc::builder::CircleBuilder::threeTanConstructor(lc::entity::CADEntity_CSPtr
     return true;
 }
 
-bool lc::builder::CircleBuilder::twoTanConstructor(lc::entity::CADEntity_CSPtr circ0, lc::entity::CADEntity_CSPtr circ1, double s1, double s2, double r, int index)
+int lc::builder::CircleBuilder::twoTanConstructor(lc::entity::CADEntity_CSPtr circ0, lc::entity::CADEntity_CSPtr circ1, double s1, double s2, double r, int index)
 {
     lc::entity::Circle_CSPtr circle0 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ0);
     lc::entity::Circle_CSPtr circle1 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ1);
 
-    // check if selected entities are in fact circles, if not return false
+    // check if selected entities are in fact circles, if not return -2
     if (circle0 == nullptr || circle1 == nullptr) {
-        return false;
+        return -2;
     }
 
     double x1 = circle0->getCenter().x();
@@ -130,7 +130,7 @@ bool lc::builder::CircleBuilder::twoTanConstructor(lc::entity::CADEntity_CSPtr c
     double y = 0;
 
     if (sol.size() == 0) {
-        return false;
+        return -1;
     }
 
     y = sol[index];
@@ -140,7 +140,7 @@ bool lc::builder::CircleBuilder::twoTanConstructor(lc::entity::CADEntity_CSPtr c
     _center = lc::geo::Coordinate(x, y);
     _radius = r;
 
-    return true;
+    return 0;
 }
 
 

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -1,6 +1,7 @@
 #include "circle.h"
 #include <cad/primitive/circle.h>
 #include <cad/math/lcmath.h>
+#include <cmath>
 
 const lc::geo::Coordinate& lc::builder::CircleBuilder::center() const {
     return _center;
@@ -110,6 +111,23 @@ int lc::builder::CircleBuilder::twoTanConstructor(lc::entity::CADEntity_CSPtr ci
     double y2 = circle1->getCenter().y();
     double r1 = circle0->getRadius();
     double r2 = circle1->getRadius();
+
+    // check if circle is completely contained by another circle, if so not possible and return -3
+    double dist = sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+    if (r1 < r2)
+    {
+        if (dist + r1 <= r2)
+        {
+            return -3;
+        }
+    }
+    else
+    {
+        if (dist + r2 <= r1)
+        {
+            return -3;
+        }
+    }
 
     double a = (r - s1 * r1) * (r - s1 * r1);
     double b = (r - s2 * r2) * (r - s2 * r2);

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -1,6 +1,6 @@
 #include "circle.h"
 #include <cad/primitive/circle.h>
-#include<iostream>
+#include <cad/math/lcmath.h>
 
 const lc::geo::Coordinate& lc::builder::CircleBuilder::center() const {
     return _center;
@@ -20,11 +20,71 @@ lc::builder::CircleBuilder* lc::builder::CircleBuilder::setRadius(double radius)
     return this;
 }
 
-lc::builder::CircleBuilder* lc::builder::CircleBuilder::threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2)
+/* Algebraic solution from Problem of Apollonius - https://en.wikipedia.org/wiki/Problem_of_Apollonius
+*  Calculation code snippet from rosettacode.org - https://rosettacode.org/wiki/Problem_of_Apollonius
+*/
+lc::builder::CircleBuilder* lc::builder::CircleBuilder::threeTanConstructor(lc::entity::CADEntity_CSPtr circ0, lc::entity::CADEntity_CSPtr circ1, lc::entity::CADEntity_CSPtr circ2, float s1, float s2, float s3)
 {
-    lc::entity::Circle_CSPtr c0 = std::dynamic_pointer_cast<const lc::entity::Circle>(circle0);
-    lc::entity::Circle_CSPtr c1 = std::dynamic_pointer_cast<const lc::entity::Circle>(circle0);
-    lc::entity::Circle_CSPtr c2 = std::dynamic_pointer_cast<const lc::entity::Circle>(circle0);
+    lc::entity::Circle_CSPtr circle0 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ0);
+    lc::entity::Circle_CSPtr circle1 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ1);
+    lc::entity::Circle_CSPtr circle2 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ2);
+
+    double x1 = circle0->getCenter().x();
+    double y1 = circle0->getCenter().y();
+    double x2 = circle1->getCenter().x();
+    double y2 = circle1->getCenter().y();
+    double x3 = circle2->getCenter().x();
+    double y3 = circle2->getCenter().y();
+    double r1 = circle0->getRadius();
+    double r2 = circle1->getRadius();
+    double r3 = circle2->getRadius();
+
+    double v11 = 2 * x2 - 2 * x1;
+    double v12 = 2 * y2 - 2 * y1;
+    double v13 = x1 * x1 - x2 * x2 + y1 * y1 - y2 * y2 - r1 * r1 + r2 * r2;
+    double v14 = 2 * s2 * r2 - 2 * s1 * r1;
+
+    double v21 = 2 * x3 - 2 * x2;
+    double v22 = 2 * y3 - 2 * y2;
+    double v23 = x2 * x2 - x3 * x3 + y2 * y2 - y3 * y3 - r2 * r2 + r3 * r3;
+    double v24 = 2 * s3 * r3 - 2 * s2 * r2;
+
+    double w12 = v12 / v11;
+    double w13 = v13 / v11;
+    double w14 = v14 / v11;
+
+    double w22 = v22 / v21 - w12;
+    double w23 = v23 / v21 - w13;
+    double w24 = v24 / v21 - w14;
+
+    double P = -w23 / w22;
+    double Q = w24 / w22;
+    double M = -w12 * P - w13;
+    double N = w14 - w12 * Q;
+
+    double a = N * N + Q * Q - 1;
+    double b = 2 * M * N - 2 * N * x1 + 2 * P * Q - 2 * Q * y1 + 2 * s1 * r1;
+    double c = x1 * x1 + M * M - 2 * M * x1 + P * P + y1 * y1 - 2 * P * y1 - r1 * r1;
+
+    std::vector<double> coffs;
+    coffs.push_back(b / a);
+    coffs.push_back(c / a);
+    std::vector<double> sol = lc::maths::Math::quadraticSolver(coffs);
+
+    double r = 0;
+    for (double d : sol) {
+        if (d > 0) {
+            r = d;
+        }
+    }
+
+    double xs = M + N * r;
+    double ys = P + Q * r;
+
+    _center = lc::geo::Coordinate(xs, ys);
+    _radius = r;
+
+    return this;
 }
 
 lc::entity::Circle_CSPtr lc::builder::CircleBuilder::build() {

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -1,5 +1,6 @@
 #include "circle.h"
 #include <cad/primitive/circle.h>
+#include<iostream>
 
 const lc::geo::Coordinate& lc::builder::CircleBuilder::center() const {
     return _center;
@@ -17,6 +18,13 @@ double lc::builder::CircleBuilder::radius() const {
 lc::builder::CircleBuilder* lc::builder::CircleBuilder::setRadius(double radius) {
     _radius = radius;
     return this;
+}
+
+lc::builder::CircleBuilder* lc::builder::CircleBuilder::threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2)
+{
+    lc::entity::Circle_CSPtr c0 = std::dynamic_pointer_cast<const lc::entity::Circle>(circle0);
+    lc::entity::Circle_CSPtr c1 = std::dynamic_pointer_cast<const lc::entity::Circle>(circle0);
+    lc::entity::Circle_CSPtr c2 = std::dynamic_pointer_cast<const lc::entity::Circle>(circle0);
 }
 
 lc::entity::Circle_CSPtr lc::builder::CircleBuilder::build() {

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -23,7 +23,7 @@ lc::builder::CircleBuilder* lc::builder::CircleBuilder::setRadius(double radius)
 /* Algebraic solution from Problem of Apollonius - https://en.wikipedia.org/wiki/Problem_of_Apollonius
 *  Calculation code snippet from rosettacode.org - https://rosettacode.org/wiki/Problem_of_Apollonius
 */
-bool lc::builder::CircleBuilder::threeTanConstructor(lc::entity::CADEntity_CSPtr circ0, lc::entity::CADEntity_CSPtr circ1, lc::entity::CADEntity_CSPtr circ2, float s1, float s2, float s3)
+bool lc::builder::CircleBuilder::threeTanConstructor(lc::entity::CADEntity_CSPtr circ0, lc::entity::CADEntity_CSPtr circ1, lc::entity::CADEntity_CSPtr circ2, double s1, double s2, double s3)
 {
     lc::entity::Circle_CSPtr circle0 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ0);
     lc::entity::Circle_CSPtr circle1 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ1);

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -23,11 +23,16 @@ lc::builder::CircleBuilder* lc::builder::CircleBuilder::setRadius(double radius)
 /* Algebraic solution from Problem of Apollonius - https://en.wikipedia.org/wiki/Problem_of_Apollonius
 *  Calculation code snippet from rosettacode.org - https://rosettacode.org/wiki/Problem_of_Apollonius
 */
-lc::builder::CircleBuilder* lc::builder::CircleBuilder::threeTanConstructor(lc::entity::CADEntity_CSPtr circ0, lc::entity::CADEntity_CSPtr circ1, lc::entity::CADEntity_CSPtr circ2, float s1, float s2, float s3)
+bool lc::builder::CircleBuilder::threeTanConstructor(lc::entity::CADEntity_CSPtr circ0, lc::entity::CADEntity_CSPtr circ1, lc::entity::CADEntity_CSPtr circ2, float s1, float s2, float s3)
 {
     lc::entity::Circle_CSPtr circle0 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ0);
     lc::entity::Circle_CSPtr circle1 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ1);
     lc::entity::Circle_CSPtr circle2 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ2);
+
+    // check if selected entities are in fact circles, if not return false
+    if (circle0 == nullptr || circle1 == nullptr || circle2 == nullptr) {
+        return false;
+    }
 
     double x1 = circle0->getCenter().x();
     double y1 = circle0->getCenter().y();
@@ -72,6 +77,8 @@ lc::builder::CircleBuilder* lc::builder::CircleBuilder::threeTanConstructor(lc::
     std::vector<double> sol = lc::maths::Math::quadraticSolver(coffs);
 
     double r = 0;
+
+    // taking only positive roots
     for (double d : sol) {
         if (d > 0) {
             r = d;
@@ -84,7 +91,7 @@ lc::builder::CircleBuilder* lc::builder::CircleBuilder::threeTanConstructor(lc::
     _center = lc::geo::Coordinate(xs, ys);
     _radius = r;
 
-    return this;
+    return true;
 }
 
 lc::entity::Circle_CSPtr lc::builder::CircleBuilder::build() {

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -94,6 +94,56 @@ bool lc::builder::CircleBuilder::threeTanConstructor(lc::entity::CADEntity_CSPtr
     return true;
 }
 
+bool lc::builder::CircleBuilder::twoTanConstructor(lc::entity::CADEntity_CSPtr circ0, lc::entity::CADEntity_CSPtr circ1, double s1, double s2, double r, int index)
+{
+    lc::entity::Circle_CSPtr circle0 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ0);
+    lc::entity::Circle_CSPtr circle1 = std::dynamic_pointer_cast<const lc::entity::Circle>(circ1);
+
+    // check if selected entities are in fact circles, if not return false
+    if (circle0 == nullptr || circle1 == nullptr) {
+        return false;
+    }
+
+    double x1 = circle0->getCenter().x();
+    double y1 = circle0->getCenter().y();
+    double x2 = circle1->getCenter().x();
+    double y2 = circle1->getCenter().y();
+    double r1 = circle0->getRadius();
+    double r2 = circle1->getRadius();
+
+    double a = (r - s1 * r1) * (r - s1 * r1);
+    double b = (r - s2 * r2) * (r - s2 * r2);
+
+    double c = ((x1 * x1 - x2 * x2) + (y1 * y1 - y2 * y2) - (a - b)) / (2 * (x1 - x2));
+    double d = (y1 - y2) / (x1 - x2);
+    double e = c - x1;
+
+    double A = d * d + 1;
+    double B = (-2 * e * d) - (2 * y1);
+    double C = (e * e) + (y1 * y1) - a;
+
+    std::vector<double> coffs;
+    coffs.push_back(B / A);
+    coffs.push_back(C / A);
+    std::vector<double> sol = lc::maths::Math::quadraticSolver(coffs);
+
+    double y = 0;
+
+    if (sol.size() == 0) {
+        return false;
+    }
+
+    y = sol[index];
+
+    double x = c - d * y;
+
+    _center = lc::geo::Coordinate(x, y);
+    _radius = r;
+
+    return true;
+}
+
+
 lc::entity::Circle_CSPtr lc::builder::CircleBuilder::build() {
     return entity::Circle_CSPtr(new entity::Circle(*this));
 }

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -35,15 +35,15 @@ bool lc::builder::CircleBuilder::threeTanConstructor(lc::entity::CADEntity_CSPtr
         return false;
     }
 
-    double x1 = circle0->getCenter().x();
-    double y1 = circle0->getCenter().y();
-    double x2 = circle1->getCenter().x();
-    double y2 = circle1->getCenter().y();
-    double x3 = circle2->getCenter().x();
-    double y3 = circle2->getCenter().y();
-    double r1 = circle0->getRadius();
-    double r2 = circle1->getRadius();
-    double r3 = circle2->getRadius();
+    double x1 = circle0->center().x();
+    double y1 = circle0->center().y();
+    double x2 = circle1->center().x();
+    double y2 = circle1->center().y();
+    double x3 = circle2->center().x();
+    double y3 = circle2->center().y();
+    double r1 = circle0->radius();
+    double r2 = circle1->radius();
+    double r3 = circle2->radius();
 
     double v11 = 2 * x2 - 2 * x1;
     double v12 = 2 * y2 - 2 * y1;
@@ -105,12 +105,15 @@ int lc::builder::CircleBuilder::twoTanConstructor(lc::entity::CADEntity_CSPtr ci
         return -2;
     }
 
-    double x1 = circle0->getCenter().x();
-    double y1 = circle0->getCenter().y();
-    double x2 = circle1->getCenter().x();
-    double y2 = circle1->getCenter().y();
-    double r1 = circle0->getRadius();
-    double r2 = circle1->getRadius();
+    _twotanCircleCenter1 = circle0->center();
+    _twotanCircleCenter2 = circle1->center();
+
+    double x1 = circle0->center().x();
+    double y1 = circle0->center().y();
+    double x2 = circle1->center().x();
+    double y2 = circle1->center().y();
+    double r1 = circle0->radius();
+    double r2 = circle1->radius();
 
     // check if circle is completely contained by another circle, if so not possible and return -3
     double dist = sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
@@ -161,6 +164,13 @@ int lc::builder::CircleBuilder::twoTanConstructor(lc::entity::CADEntity_CSPtr ci
     return 0;
 }
 
+const std::vector<lc::geo::Coordinate> lc::builder::CircleBuilder::twoTanCircleCenters() const
+{
+    std::vector<lc::geo::Coordinate> res;
+    res.push_back(_twotanCircleCenter1);
+    res.push_back(_twotanCircleCenter2);
+    return res;
+}
 
 lc::entity::Circle_CSPtr lc::builder::CircleBuilder::build() {
     return entity::Circle_CSPtr(new entity::Circle(*this));

--- a/lckernel/cad/builders/circle.h
+++ b/lckernel/cad/builders/circle.h
@@ -25,8 +25,11 @@ namespace lc {
                  * @return construction was successful or not
                  */
                 bool threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2, double s1, double s2, double s3);
-                bool twoTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, double s1, double s2, double r, int index);
 
+                /*
+                *   @return 0 - successful, -1 - given s0,s1 don't yield a real solution, -2 - not circle entities
+                */
+                int twoTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, double s1, double s2, double r, int index);
 
             private:
                 geo::Coordinate _center;

--- a/lckernel/cad/builders/circle.h
+++ b/lckernel/cad/builders/circle.h
@@ -27,7 +27,10 @@ namespace lc {
                 bool threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2, double s1, double s2, double s3);
 
                 /*
+                *   @brief circle tangent to two other circle given radius
+                *   @param CADEntity_CSPtr to two circle entities, s0,s1,radius and index to choose among solutions
                 *   @return 0 - successful, -1 - given s0,s1 don't yield a real solution, -2 - not circle entities
+                *           -3 - not possible given any s0,s1
                 */
                 int twoTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, double s1, double s2, double r, int index);
 

--- a/lckernel/cad/builders/circle.h
+++ b/lckernel/cad/builders/circle.h
@@ -17,7 +17,14 @@ namespace lc {
                 CircleBuilder* setRadius(double radius);
 
                 entity::Circle_CSPtr build();
-                CircleBuilder* threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2);
+
+                /**
+                 * @brief circle tangent to three other circle
+                 * @param CADEntity_CSPtr to three circle entities, s0, s1, s2 - combination of 1 and -1
+                 *        would yield 8 solutions
+                 * @return CircleBuilder* pointer to the circle builder
+                 */
+                CircleBuilder* threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2, float s0, float s1, float s2);
 
             private:
                 geo::Coordinate _center;

--- a/lckernel/cad/builders/circle.h
+++ b/lckernel/cad/builders/circle.h
@@ -17,6 +17,7 @@ namespace lc {
                 CircleBuilder* setRadius(double radius);
 
                 entity::Circle_CSPtr build();
+                CircleBuilder* threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2);
 
             private:
                 geo::Coordinate _center;

--- a/lckernel/cad/builders/circle.h
+++ b/lckernel/cad/builders/circle.h
@@ -25,6 +25,8 @@ namespace lc {
                  * @return construction was successful or not
                  */
                 bool threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2, double s1, double s2, double s3);
+                bool twoTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, double s1, double s2, double r, int index);
+
 
             private:
                 geo::Coordinate _center;

--- a/lckernel/cad/builders/circle.h
+++ b/lckernel/cad/builders/circle.h
@@ -22,9 +22,9 @@ namespace lc {
                  * @brief circle tangent to three other circle
                  * @param CADEntity_CSPtr to three circle entities, s0, s1, s2 - combination of 1 and -1
                  *        would yield 8 solutions
-                 * @return CircleBuilder* pointer to the circle builder
+                 * @return construction was successful or not
                  */
-                CircleBuilder* threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2, float s0, float s1, float s2);
+                bool threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2, float s0, float s1, float s2);
 
             private:
                 geo::Coordinate _center;

--- a/lckernel/cad/builders/circle.h
+++ b/lckernel/cad/builders/circle.h
@@ -34,9 +34,13 @@ namespace lc {
                 */
                 int twoTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, double s1, double s2, double r, int index);
 
+                const std::vector<lc::geo::Coordinate> twoTanCircleCenters() const;
+
             private:
                 geo::Coordinate _center;
                 double _radius;
+                geo::Coordinate _twotanCircleCenter1;
+                geo::Coordinate _twotanCircleCenter2;
         };
     }
 }

--- a/lckernel/cad/builders/circle.h
+++ b/lckernel/cad/builders/circle.h
@@ -24,7 +24,7 @@ namespace lc {
                  *        would yield 8 solutions
                  * @return construction was successful or not
                  */
-                bool threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2, float s0, float s1, float s2);
+                bool threeTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, lc::entity::CADEntity_CSPtr circle2, double s1, double s2, double s3);
 
             private:
                 geo::Coordinate _center;

--- a/lckernel/cad/primitive/circle.cpp
+++ b/lckernel/cad/primitive/circle.cpp
@@ -110,13 +110,3 @@ CADEntity_CSPtr Circle::modify(meta::Layer_CSPtr layer, const meta::MetaInfo_CSP
     return newEntity;
 }
 
-const geo::Coordinate& Circle::getCenter() const
-{
-    return center_circle;
-}
-
-double Circle::getRadius() const
-{
-    return radius_circle;
-}
-

--- a/lckernel/cad/primitive/circle.cpp
+++ b/lckernel/cad/primitive/circle.cpp
@@ -12,17 +12,19 @@ Circle::Circle(const geo::Coordinate &center,
                meta::MetaInfo_CSPtr metaInfo,
                meta::Block_CSPtr block) :
         CADEntity(std::move(layer), std::move(metaInfo), std::move(block)),
-        geo::Circle(center, radius) {
+        geo::Circle(center, radius) , center_circle(center), radius_circle(radius){
 }
 
 
 Circle::Circle(const Circle_CSPtr& other, bool sameID) : CADEntity(other, sameID),
-                                                        geo::Circle(other->center(), other->radius()) {
+                                                        geo::Circle(other->center(), other->radius()),
+                                                        center_circle(other->center()), radius_circle(other->radius()) {
 }
 
 Circle::Circle(const builder::CircleBuilder& builder) :
     CADEntity(builder),
-    geo::Circle(builder.center(), builder.radius()) {
+    geo::Circle(builder.center(), builder.radius()),
+    center_circle(builder.center()), radius_circle(builder.radius()) {
 }
 
 std::vector<EntityCoordinate> Circle::snapPoints(const geo::Coordinate &coord, const SimpleSnapConstrain &constrain,
@@ -108,4 +110,13 @@ CADEntity_CSPtr Circle::modify(meta::Layer_CSPtr layer, const meta::MetaInfo_CSP
     return newEntity;
 }
 
+geo::Coordinate Circle::getCenter() const
+{
+    return center_circle;
+}
+
+double Circle::getRadius() const
+{
+    return radius_circle;
+}
 

--- a/lckernel/cad/primitive/circle.cpp
+++ b/lckernel/cad/primitive/circle.cpp
@@ -110,7 +110,7 @@ CADEntity_CSPtr Circle::modify(meta::Layer_CSPtr layer, const meta::MetaInfo_CSP
     return newEntity;
 }
 
-geo::Coordinate Circle::getCenter() const
+const geo::Coordinate& Circle::getCenter() const
 {
     return center_circle;
 }

--- a/lckernel/cad/primitive/circle.h
+++ b/lckernel/cad/primitive/circle.h
@@ -42,6 +42,8 @@ namespace lc {
 
             virtual geo::Coordinate nearestPointOnPath(const geo::Coordinate &coord) const override;
 
+            geo::Coordinate getCenter() const;
+            double getRadius() const;
         public:
 
             /**
@@ -95,7 +97,8 @@ namespace lc {
 
         private:
             Circle(const builder::CircleBuilder& builder);
-
+            geo::Coordinate center_circle;
+            double radius_circle;
         };
 
         DECLARE_SHORT_SHARED_PTR(Circle)

--- a/lckernel/cad/primitive/circle.h
+++ b/lckernel/cad/primitive/circle.h
@@ -41,9 +41,6 @@ namespace lc {
                                                              int maxNumberOfSnapPoints) const override;
 
             virtual geo::Coordinate nearestPointOnPath(const geo::Coordinate &coord) const override;
-
-            const geo::Coordinate& getCenter() const;
-            double getRadius() const;
         public:
 
             /**

--- a/lckernel/cad/primitive/circle.h
+++ b/lckernel/cad/primitive/circle.h
@@ -42,7 +42,7 @@ namespace lc {
 
             virtual geo::Coordinate nearestPointOnPath(const geo::Coordinate &coord) const override;
 
-            geo::Coordinate getCenter() const;
+            const geo::Coordinate& getCenter() const;
             double getRadius() const;
         public:
 


### PR DESCRIPTION
This PR implements the circle tangent to three other circles feature.

Algebraic solution of problem of apollonius is used.

Select the three circles and then choose the 3 tan option from the create menu.
Now move the mouse around to cycle through the 8 possible solutions, click to confirm the desired circle.

Also implements circle tangent to two circle with given radius.
Move mouse to adjust radius and choose among two possible solutions.