### PR TITLE
Better display of temporary entities for three tan circle operation

### DIFF
--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -225,6 +225,30 @@ function CircleOperations:getCircleWith3TansOptions(newPos)
     end
 end
 
+function CircleOperations:drawAllTan3Circles()
+    self.builder:modifyForTempEntity(true)
+    local b = lc.operation.EntityBuilder(getWindow(self.target_widget):document())
+    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], -1, -1, -1)
+    b:appendEntity(self.builder:build())
+    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, 1, 1)
+    b:appendEntity(self.builder:build())
+    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, -1, 1)
+    b:appendEntity(self.builder:build())
+    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], -1, 1, -1)
+    b:appendEntity(self.builder:build())
+    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], -1, -1, 1)
+    b:appendEntity(self.builder:build())
+    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, -1, -1)
+    b:appendEntity(self.builder:build())
+    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], -1, 1, 1)
+    b:appendEntity(self.builder:build())
+    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, 1, -1)
+    b:appendEntity(self.builder:build())
+    self.builder:modifyForTempEntity(false)
+
+    b:execute()
+end
+
 function CircleOperations:getIndexForCircleWithTwoTan(newPos)
     local angle = self.twocirclecenters[1]:angleBetween(self.twocirclecenters[2], newPos)
     if(angle > 0) then
@@ -254,6 +278,7 @@ function CircleOperations:CircleWith3Tans(eventName, data)
                 finish_operation(self.target_widget)
             end
         else
+            self:drawAllTan3Circles()
             local s1,s2,s3 = self:getCircleWith3TansOptions(data["position"])
             self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], s1, s2, s3)
             self:refreshTempEntity()

--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -227,26 +227,25 @@ end
 
 function CircleOperations:drawAllTan3Circles()
     self.builder:modifyForTempEntity(true)
-    local b = lc.operation.EntityBuilder(getWindow(self.target_widget):document())
-    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], -1, -1, -1)
-    b:appendEntity(self.builder:build())
-    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, 1, 1)
-    b:appendEntity(self.builder:build())
-    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, -1, 1)
-    b:appendEntity(self.builder:build())
-    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], -1, 1, -1)
-    b:appendEntity(self.builder:build())
-    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], -1, -1, 1)
-    b:appendEntity(self.builder:build())
-    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, -1, -1)
-    b:appendEntity(self.builder:build())
-    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], -1, 1, 1)
-    b:appendEntity(self.builder:build())
-    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, 1, -1)
-    b:appendEntity(self.builder:build())
+    local oldId =self.builder:id()
+    self.temp3tans = lc.operation.EntityBuilder(getWindow(self.target_widget):document())
+
+    for i=-1,1 do
+        for j=-1,1 do
+            for k=-1,1 do
+                if (i~=0 and j~=0 and k~=0) then
+                    self.builder:newID()
+                    self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], i, j, k)
+                    self.temp3tans:appendEntity(self.builder:build())
+                end
+            end
+        end
+    end
+
+    self.builder:setID(oldId)
     self.builder:modifyForTempEntity(false)
 
-    b:execute()
+    self.temp3tans:execute()
 end
 
 function CircleOperations:getIndexForCircleWithTwoTan(newPos)
@@ -277,14 +276,18 @@ function CircleOperations:CircleWith3Tans(eventName, data)
                 message("THREE circle entities should be selected", self.target_widget)
                 finish_operation(self.target_widget)
             end
-        else
             self:drawAllTan3Circles()
+        else
             local s1,s2,s3 = self:getCircleWith3TansOptions(data["position"])
             self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], s1, s2, s3)
             self:refreshTempEntity()
         end
     elseif(eventName == "point") then
         self:createEntity()
+        self.temp3tans:appendOperation(lc.operation.Push())
+        self.temp3tans:appendOperation(lc.operation.Remove())
+        self.temp3tans:execute()
+        self.constructed3tan = false
     end
 end
 
@@ -333,4 +336,12 @@ function CircleOperations:Circumcenter(Point1,Point2,Point3)
     local Y = (Point1:y() * math.sin(2 * Angle1) + Point2:y() * math.sin(2 * Angle2) + Point3:y() * math.sin(2 * Angle3) ) / ( math.sin(2 * Angle1) + math.sin(2 * Angle2) + math.sin(2 * Angle3))
     local Output=lc.geo.Coordinate(X,Y)
     return Output
+end
+
+function CircleOperations:cleanUp()
+    if (self.constructed3tan) then
+        self.temp3tans:appendOperation(lc.operation.Push())
+        self.temp3tans:appendOperation(lc.operation.Remove())
+        self.temp3tans:execute()
+    end
 end

--- a/lcUILua/createActions/createOperations.lua
+++ b/lcUILua/createActions/createOperations.lua
@@ -85,6 +85,9 @@ function CreateOperations:close()
     if(not self.finished) then
         luaInterface:triggerEvent('operationFinished', self.target_widget)
         self:removeTempEntity()
+        if (self.cleanUp ~= nil) then
+            self:cleanUp()
+        end
         self:unregisterEvents()
         cli_get_text(self.target_widget, false)
         cli_command_active(self.target_widget, false)

--- a/lcadluascript/bridge/lc_builder.cpp
+++ b/lcadluascript/bridge/lc_builder.cpp
@@ -91,6 +91,7 @@ void import_lc_builder_namespace(kaguya::State& state) {
         .addFunction("threeTanConstructor", &lc::builder::CircleBuilder::threeTanConstructor)
         .addFunction("twoTanConstructor", &lc::builder::CircleBuilder::twoTanConstructor)
         .addFunction("twoTanCircleCenters", &lc::builder::CircleBuilder::twoTanCircleCenters)
+        .addFunction("modifyForTempEntity", &lc::builder::CircleBuilder::modifyForTempEntity)
     );
 
 

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -7,7 +7,8 @@ lc::builder::CircleBuilder::CircleBuilder() {
     // creating the temporary line pattern
     lc::builder::LinePatternBuilder lp_builder;
     lp_builder.setName("tempEntity");
-    lp_builder.addElement(10);
+    lp_builder.addElement(1);
+    lp_builder.addElement(-10);
 
     linePattern = lp_builder.build();
 }
@@ -186,8 +187,8 @@ void lc::builder::CircleBuilder::modifyForTempEntity(bool val)
     tempEntity = val;
 }
 
-lc::entity::Circle_CSPtr lc::builder::CircleBuilder::build() {
-
+lc::entity::Circle_CSPtr lc::builder::CircleBuilder::build()
+{
     if (tempEntity)
     {
         lc::entity::Circle_CSPtr new_circle = entity::Circle_CSPtr(new entity::Circle(*this));

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -172,6 +172,25 @@ const std::vector<lc::geo::Coordinate> lc::builder::CircleBuilder::twoTanCircleC
     return res;
 }
 
+void lc::builder::CircleBuilder::modifyForTempEntity(bool val)
+{
+    tempEntity = val;
+}
+
 lc::entity::Circle_CSPtr lc::builder::CircleBuilder::build() {
-    return entity::Circle_CSPtr(new entity::Circle(*this));
+
+    if (tempEntity)
+    {
+        lc::entity::Circle_CSPtr new_circle = entity::Circle_CSPtr(new entity::Circle(*this));
+        lc::meta::Layer_CSPtr oldLayer = new_circle->layer();
+        lc::meta::MetaLineWidthByValue newWidth = lc::meta::MetaLineWidthByValue(oldLayer->lineWidth().width() / 2);
+        lc::meta::DxfLinePatternByValue_CSPtr linePattern = oldLayer->linePattern();
+        lc::meta::Layer* tempLayer = new lc::meta::Layer(oldLayer->name(), newWidth, oldLayer->color(), oldLayer->linePattern(), oldLayer->isFrozen());
+
+        return std::dynamic_pointer_cast<const lc::entity::Circle>(new_circle->modify(lc::meta::Layer_CSPtr(tempLayer), new_circle->metaInfo(), new_circle->block()));
+    }
+    else
+    {
+        return entity::Circle_CSPtr(new entity::Circle(*this));;
+    }
 }

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -3,6 +3,15 @@
 #include <cad/math/lcmath.h>
 #include <cmath>
 
+lc::builder::CircleBuilder::CircleBuilder() {
+    // creating the temporary line pattern
+    lc::builder::LinePatternBuilder lp_builder;
+    lp_builder.setName("tempEntity");
+    lp_builder.addElement(10);
+
+    linePattern = lp_builder.build();
+}
+
 const lc::geo::Coordinate& lc::builder::CircleBuilder::center() const {
     return _center;
 }
@@ -183,9 +192,8 @@ lc::entity::Circle_CSPtr lc::builder::CircleBuilder::build() {
     {
         lc::entity::Circle_CSPtr new_circle = entity::Circle_CSPtr(new entity::Circle(*this));
         lc::meta::Layer_CSPtr oldLayer = new_circle->layer();
-        lc::meta::MetaLineWidthByValue newWidth = lc::meta::MetaLineWidthByValue(oldLayer->lineWidth().width() / 2);
-        lc::meta::DxfLinePatternByValue_CSPtr linePattern = oldLayer->linePattern();
-        lc::meta::Layer* tempLayer = new lc::meta::Layer(oldLayer->name(), newWidth, oldLayer->color(), oldLayer->linePattern(), oldLayer->isFrozen());
+
+        lc::meta::Layer* tempLayer = new lc::meta::Layer(oldLayer->name(), oldLayer->lineWidth(), oldLayer->color(), linePattern, oldLayer->isFrozen());
 
         return std::dynamic_pointer_cast<const lc::entity::Circle>(new_circle->modify(lc::meta::Layer_CSPtr(tempLayer), new_circle->metaInfo(), new_circle->block()));
     }

--- a/lckernel/cad/builders/circle.h
+++ b/lckernel/cad/builders/circle.h
@@ -7,7 +7,7 @@ namespace lc {
     namespace builder {
         class CircleBuilder : public CADEntityBuilder {
             public:
-                CircleBuilder() = default;
+                CircleBuilder();
                 virtual ~CircleBuilder() = default;
 
                 const geo::Coordinate& center() const;
@@ -43,6 +43,7 @@ namespace lc {
                 geo::Coordinate _twotanCircleCenter1;
                 geo::Coordinate _twotanCircleCenter2;
                 bool tempEntity = false;
+                lc::meta::DxfLinePatternByValue_CSPtr linePattern;
         };
     }
 }

--- a/lckernel/cad/builders/circle.h
+++ b/lckernel/cad/builders/circle.h
@@ -35,12 +35,14 @@ namespace lc {
                 int twoTanConstructor(lc::entity::CADEntity_CSPtr circle0, lc::entity::CADEntity_CSPtr circle1, double s1, double s2, double r, int index);
 
                 const std::vector<lc::geo::Coordinate> twoTanCircleCenters() const;
+                void modifyForTempEntity(bool val);
 
             private:
                 geo::Coordinate _center;
                 double _radius;
                 geo::Coordinate _twotanCircleCenter1;
                 geo::Coordinate _twotanCircleCenter2;
+                bool tempEntity = false;
         };
     }
 }

--- a/lckernel/cad/primitive/circle.cpp
+++ b/lckernel/cad/primitive/circle.cpp
@@ -12,19 +12,17 @@ Circle::Circle(const geo::Coordinate &center,
                meta::MetaInfo_CSPtr metaInfo,
                meta::Block_CSPtr block) :
         CADEntity(std::move(layer), std::move(metaInfo), std::move(block)),
-        geo::Circle(center, radius) , center_circle(center), radius_circle(radius){
+        geo::Circle(center, radius){
 }
 
 
 Circle::Circle(const Circle_CSPtr& other, bool sameID) : CADEntity(other, sameID),
-                                                        geo::Circle(other->center(), other->radius()),
-                                                        center_circle(other->center()), radius_circle(other->radius()) {
+                                                        geo::Circle(other->center(), other->radius()) {
 }
 
 Circle::Circle(const builder::CircleBuilder& builder) :
     CADEntity(builder),
-    geo::Circle(builder.center(), builder.radius()),
-    center_circle(builder.center()), radius_circle(builder.radius()) {
+    geo::Circle(builder.center(), builder.radius()){
 }
 
 std::vector<EntityCoordinate> Circle::snapPoints(const geo::Coordinate &coord, const SimpleSnapConstrain &constrain,

--- a/lckernel/cad/primitive/circle.h
+++ b/lckernel/cad/primitive/circle.h
@@ -94,8 +94,6 @@ namespace lc {
 
         private:
             Circle(const builder::CircleBuilder& builder);
-            geo::Coordinate center_circle;
-            double radius_circle;
         };
 
         DECLARE_SHORT_SHARED_PTR(Circle)


### PR DESCRIPTION
All possible solutions are shown in a different line pattern so that the user can see all available options without having to move the mouse around to look for different circles.
Clicking escape or selecting a circle by clicking removes these temporary circles.