### PR TITLE
Bug fixes for temporary circle creation in 3 tan function

### DIFF
--- a/lcUILua/createActions/circleoperations.lua
+++ b/lcUILua/createActions/circleoperations.lua
@@ -262,12 +262,14 @@ function CircleOperations:CircleWith3Tans(eventName, data)
         if(self.constructed3tan ~= true) then
             self.selection = getWindow(self.target_widget):selection()
             self.initialMousePosition = data["position"]
+            local successful = false
             if(#self.selection == 3) then
                 local success = self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], 1, 1, 1)
                 if success == false then
                     message("Entities selected MUST be circles", self.target_widget)
                     finish_operation(self.target_widget)
                 else
+                    successful = true
                     self:refreshTempEntity()
                     self.constructed3tan = true
                     message("Move mouse around to cycle through different circles", self.target_widget)
@@ -276,7 +278,9 @@ function CircleOperations:CircleWith3Tans(eventName, data)
                 message("THREE circle entities should be selected", self.target_widget)
                 finish_operation(self.target_widget)
             end
-            self:drawAllTan3Circles()
+            if (successful) then
+                self:drawAllTan3Circles()
+            end
         else
             local s1,s2,s3 = self:getCircleWith3TansOptions(data["position"])
             self.builder:threeTanConstructor(self.selection[1], self.selection[2], self.selection[3], s1, s2, s3)

--- a/lckernel/cad/builders/circle.cpp
+++ b/lckernel/cad/builders/circle.cpp
@@ -192,11 +192,39 @@ lc::entity::Circle_CSPtr lc::builder::CircleBuilder::build()
     if (tempEntity)
     {
         lc::entity::Circle_CSPtr new_circle = entity::Circle_CSPtr(new entity::Circle(*this));
-        lc::meta::Layer_CSPtr oldLayer = new_circle->layer();
+        lc::meta::MetaInfo_CSPtr metaInfo = new_circle->metaInfo();
+        lc::meta::MetaInfo_SPtr newMetaInfo = lc::meta::MetaInfo::create();
 
-        lc::meta::Layer* tempLayer = new lc::meta::Layer(oldLayer->name(), oldLayer->lineWidth(), oldLayer->color(), linePattern, oldLayer->isFrozen());
+        if (metaInfo && metaInfo->size() != 0)
+        {
+            newMetaInfo->add(linePattern);
 
-        return std::dynamic_pointer_cast<const lc::entity::Circle>(new_circle->modify(lc::meta::Layer_CSPtr(tempLayer), new_circle->metaInfo(), new_circle->block()));
+            try
+            {
+                const lc::meta::EntityMetaType_CSPtr lineWidth = metaInfo->at("_LINEWIDTH");
+                newMetaInfo->add(std::move(lineWidth));
+            }
+            catch (std::out_of_range & e)
+            {
+                // Do nothing
+            }
+
+            try
+            {
+                const lc::meta::EntityMetaType_CSPtr color = metaInfo->at("_COLOR");
+                newMetaInfo->add(std::move(color));
+            }
+            catch (std::out_of_range & e)
+            {
+                // Do nothing
+            }
+        }
+        else
+        {
+            newMetaInfo->add(linePattern);
+        }
+
+        return std::dynamic_pointer_cast<const lc::entity::Circle>(new_circle->modify(new_circle->layer(), newMetaInfo, new_circle->block()));
     }
     else
     {


### PR DESCRIPTION
Commit 1 - On invalid selection it was crashing, because drawAll3Tans was being called in those cases too.

Commit 2 - Line pattern wasn't changing on changing the line pattern through the line pattern select.
Changing metainfo now instead of layer line pattern.