### PR TITLE
Fix dimensions modification bug

### DIFF
--- a/lckernel/cad/primitive/dimaligned.cpp
+++ b/lckernel/cad/primitive/dimaligned.cpp
@@ -130,8 +130,22 @@ CADEntity_CSPtr DimAligned::mirror(const geo::Coordinate& axis1,
 }
 
 const geo::Area DimAligned::boundingBox() const {
-    // TODO create proper bounding box for DimAligned
-    return geo::Area(this->middleOfText(), 0., 0.);
+    lc::geo::Vector vec23(_definitionPoint2, _definitionPoint3);
+    auto vec23eq = vec23.equation();
+    const std::vector<double> vec23coeffs = vec23eq.Coefficients();
+    double d1 = vec23coeffs[3] * this->definitionPoint().x() + vec23coeffs[4] * this->definitionPoint().y() + vec23coeffs[5];
+    double dist = std::abs(d1) / std::sqrt(vec23coeffs[3] * vec23coeffs[3] + vec23coeffs[4] * vec23coeffs[4]);
+
+    lc::geo::Coordinate geo23 = _definitionPoint3 - _definitionPoint2;
+    geo23 = geo23.norm().rotate(d1 >= 0 ? (M_PI/2) : (-M_PI/2));
+    geo23 = geo23 * dist;
+    lc::geo::Coordinate rectPoint2 = _definitionPoint2 + geo23;
+    lc::geo::Coordinate rectPoint3 = _definitionPoint3 + geo23;
+    
+    lc::geo::Coordinate minPoints = lc::geo::Coordinate(std::min(_definitionPoint2.x(), std::min(_definitionPoint3.x(), std::min(rectPoint2.x(), rectPoint3.x()))), std::min(_definitionPoint2.y(), std::min(_definitionPoint3.y(), std::min(rectPoint2.y(), rectPoint3.y()))));
+    lc::geo::Coordinate maxPoints = lc::geo::Coordinate(std::max(_definitionPoint2.x(), std::max(_definitionPoint3.x(), std::max(rectPoint2.x(), rectPoint3.x()))), std::max(_definitionPoint2.y(), std::max(_definitionPoint3.y(), std::max(rectPoint2.y(), rectPoint3.y()))));
+
+    return geo::Area(minPoints, maxPoints);
 }
 
 CADEntity_CSPtr DimAligned::modify(meta::Layer_CSPtr layer, const meta::MetaInfo_CSPtr metaInfo, meta::Block_CSPtr block) const {

--- a/lckernel/cad/primitive/dimaligned.cpp
+++ b/lckernel/cad/primitive/dimaligned.cpp
@@ -91,6 +91,7 @@ CADEntity_CSPtr DimAligned::rotate(const geo::Coordinate& rotation_center, doubl
                          this->_definitionPoint3.rotate(rotation_center, rotation_angle),
                          this->layer(), metaInfo(), block()
                                                      );
+    newDimAligned->setID(this->id());
     return newDimAligned;
 }
 
@@ -106,6 +107,7 @@ CADEntity_CSPtr DimAligned::scale(const geo::Coordinate& scale_center, const geo
                          this->_definitionPoint3.scale(scale_center, scale_factor),
                          this->layer(), metaInfo(), block()
                                                      );
+    newDimAligned->setID(this->id());
     return newDimAligned;
 }
 
@@ -123,6 +125,7 @@ CADEntity_CSPtr DimAligned::mirror(const geo::Coordinate& axis1,
                          this->_definitionPoint3.mirror(axis1, axis2),
                          this->layer(), metaInfo(), block()
                                                      );
+    newDimAligned->setID(this->id());
     return newDimAligned;
 }
 
@@ -147,6 +150,7 @@ CADEntity_CSPtr DimAligned::modify(meta::Layer_CSPtr layer, const meta::MetaInfo
                              block
                          );
 
+    newDimAligned->setID(this->id());
     return newDimAligned;
 }
 

--- a/lckernel/cad/primitive/dimangular.cpp
+++ b/lckernel/cad/primitive/dimangular.cpp
@@ -112,6 +112,7 @@ CADEntity_CSPtr DimAngular::rotate(const geo::Coordinate& rotation_center, const
                              layer(),
                              metaInfo()
                          );
+    newDimAngular->setID(this->id());
     return newDimAngular;
 }
 
@@ -131,6 +132,7 @@ CADEntity_CSPtr DimAngular::scale(const geo::Coordinate& scale_center, const geo
                              layer(),
                              metaInfo()
                          );
+    newDimAngular->setID(this->id());
     return newDimAngular;
 }
 
@@ -150,6 +152,7 @@ CADEntity_CSPtr DimAngular::mirror(const geo::Coordinate& axis1, const geo::Coor
                              layer(),
                              metaInfo()
                          );
+    newDimAngular->setID(this->id());
     return newDimAngular;
 }
 
@@ -175,7 +178,7 @@ CADEntity_CSPtr DimAngular::modify(meta::Layer_CSPtr layer, meta::MetaInfo_CSPtr
                              metaInfo,
                              block
                          );
-
+    newDimAngular->setID(this->id());
     return newDimAngular;
 }
 

--- a/lckernel/cad/primitive/dimangular.cpp
+++ b/lckernel/cad/primitive/dimangular.cpp
@@ -157,8 +157,10 @@ CADEntity_CSPtr DimAngular::mirror(const geo::Coordinate& axis1, const geo::Coor
 }
 
 const geo::Area DimAngular::boundingBox() const {
-    // TODO create proper bounding box for DimAngular
-    return geo::Area(this->middleOfText(), 0., 0.);
+    double radius = (this->middleOfText() - this->definitionPoint()).magnitude();
+    lc::geo::Coordinate topLeft = this->definitionPoint() + (lc::geo::Coordinate(-radius, radius));
+    lc::geo::Coordinate bottomRight = this->definitionPoint() + (lc::geo::Coordinate(radius, -radius));
+    return geo::Area(topLeft, bottomRight);
 }
 
 CADEntity_CSPtr DimAngular::modify(meta::Layer_CSPtr layer, meta::MetaInfo_CSPtr metaInfo, meta::Block_CSPtr block) const {

--- a/lckernel/cad/primitive/dimdiametric.cpp
+++ b/lckernel/cad/primitive/dimdiametric.cpp
@@ -88,6 +88,7 @@ CADEntity_CSPtr DimDiametric::rotate(const geo::Coordinate& rotation_center, con
                                this->_definitionPoint2.rotate(rotation_center, rotation_angle),
                                this->_leader,
                                this->layer(), metaInfo(), block());
+    newDimDiametric->setID(this->id());
     return newDimDiametric;
 }
 
@@ -102,6 +103,7 @@ CADEntity_CSPtr DimDiametric::scale(const geo::Coordinate& scale_center, const g
                            this->_definitionPoint2.scale(scale_center, scale_factor),
                            this->_leader,
                            this->layer(), metaInfo(), block());
+    newDimDiametric->setID(this->id());
     return newDimDiametric;
 }
 
@@ -116,6 +118,7 @@ CADEntity_CSPtr DimDiametric::mirror(const geo::Coordinate& axis1, const geo::Co
                            this->_definitionPoint2.mirror(axis1, axis2),
                            this->_leader,
                            this->layer(), metaInfo(), block());
+    newDimDiametric->setID(this->id());
     return newDimDiametric;
 }
 
@@ -139,7 +142,7 @@ CADEntity_CSPtr DimDiametric::modify(meta::Layer_CSPtr layer, const meta::MetaIn
                                metaInfo,
                                block
                            );
-
+    newDimDiametric->setID(this->id());
     return newDimDiametric;
 }
 

--- a/lckernel/cad/primitive/dimdiametric.cpp
+++ b/lckernel/cad/primitive/dimdiametric.cpp
@@ -123,8 +123,7 @@ CADEntity_CSPtr DimDiametric::mirror(const geo::Coordinate& axis1, const geo::Co
 }
 
 const geo::Area DimDiametric::boundingBox() const {
-    // TODO create proper bounding box for DimLinear
-    return geo::Area(this->middleOfText(), 0., 0.);
+    return geo::Area(this->definitionPoint(), this->definitionPoint2());
 }
 
 CADEntity_CSPtr DimDiametric::modify(meta::Layer_CSPtr layer, const meta::MetaInfo_CSPtr metaInfo, meta::Block_CSPtr block) const {

--- a/lckernel/cad/primitive/dimlinear.cpp
+++ b/lckernel/cad/primitive/dimlinear.cpp
@@ -103,6 +103,7 @@ CADEntity_CSPtr DimLinear::rotate(const geo::Coordinate& rotation_center, double
                         this->_oblique,
                         this->layer(), metaInfo(), block()
                                                    );
+    newDimLinear->setID(this->id());
     return newDimLinear;
 }
 
@@ -120,6 +121,7 @@ CADEntity_CSPtr DimLinear::scale(const geo::Coordinate& scale_center, const geo:
                         this->_oblique,
                         this->layer(), metaInfo(), block()
                                                    );
+    newDimLinear->setID(this->id());
     return newDimLinear;
 }
 
@@ -145,7 +147,7 @@ CADEntity_CSPtr DimLinear::modify(meta::Layer_CSPtr layer, meta::MetaInfo_CSPtr 
                             metaInfo,
                             block
                         );
-
+    newDimLinear->setID(this->id());
     return newDimLinear;
 }
 

--- a/lckernel/cad/primitive/dimlinear.cpp
+++ b/lckernel/cad/primitive/dimlinear.cpp
@@ -126,8 +126,9 @@ CADEntity_CSPtr DimLinear::scale(const geo::Coordinate& scale_center, const geo:
 }
 
 const geo::Area DimLinear::boundingBox() const {
-    // TODO create proper bounding box for DimLinear
-    return geo::Area(this->middleOfText(), 0., 0.);
+    lc::geo::Coordinate minPoints = lc::geo::Coordinate(std::min(definitionPoint().x(), std::min(definitionPoint2().x(), definitionPoint3().x())), std::min(definitionPoint().y(), std::min(definitionPoint2().y(), definitionPoint3().y())));
+    lc::geo::Coordinate maxPoints = lc::geo::Coordinate(std::max(definitionPoint().x(), std::max(definitionPoint2().x(), definitionPoint3().x())), std::max(definitionPoint().y(), std::max(definitionPoint2().y(), definitionPoint3().y())));
+    return geo::Area(minPoints, maxPoints);
 }
 
 CADEntity_CSPtr DimLinear::modify(meta::Layer_CSPtr layer, meta::MetaInfo_CSPtr metaInfo, meta::Block_CSPtr block) const {

--- a/lckernel/cad/primitive/dimradial.cpp
+++ b/lckernel/cad/primitive/dimradial.cpp
@@ -128,8 +128,7 @@ CADEntity_CSPtr DimRadial::mirror(const geo::Coordinate& axis1, const geo::Coord
 }
 
 const geo::Area DimRadial::boundingBox() const {
-    // TODO create proper bounding box for DimLinear
-    return geo::Area(this->middleOfText(), 0., 0.);
+    return geo::Area(this->middleOfText(), this->definitionPoint2());
 }
 
 CADEntity_CSPtr DimRadial::modify(meta::Layer_CSPtr layer, meta::MetaInfo_CSPtr metaInfo, meta::Block_CSPtr block) const {

--- a/lckernel/cad/primitive/dimradial.cpp
+++ b/lckernel/cad/primitive/dimradial.cpp
@@ -91,6 +91,7 @@ CADEntity_CSPtr DimRadial::rotate(const geo::Coordinate& rotation_center, double
                         this->_leader,
                         this->layer(), metaInfo(), block()
                                                    );
+    newDimRadial->setID(this->id());
     return newDimRadial;
 }
 
@@ -106,6 +107,7 @@ CADEntity_CSPtr DimRadial::scale(const geo::Coordinate& scale_center, const geo:
                         this->_leader,
                         this->layer(), metaInfo(), block()
                                                    );
+    newDimRadial->setID(this->id());
     return newDimRadial;
 }
 
@@ -121,6 +123,7 @@ CADEntity_CSPtr DimRadial::mirror(const geo::Coordinate& axis1, const geo::Coord
                         this->_leader,
                         this->layer(), metaInfo(), block()
                                                    );
+    newDimRadial->setID(this->id());
     return newDimRadial;
 }
 
@@ -143,7 +146,7 @@ CADEntity_CSPtr DimRadial::modify(meta::Layer_CSPtr layer, meta::MetaInfo_CSPtr 
                             layer,
                             metaInfo, block
                         );
-
+    newDimRadial->setID(this->id());
     return newDimRadial;
 }
 


### PR DESCRIPTION
Closes #238 , the new modified dimension dind't have the same entity id set because of which it wasn't removed in the insertEntity function and hence the old copy persisted.

Closes #237 , implemented bounding box functions for the dimensions.