### PR TITLE
Change from C to CXX tynispline interface

### DIFF
--- a/lckernel/cad/geometry/geospline.cpp
+++ b/lckernel/cad/geometry/geospline.cpp
@@ -100,7 +100,7 @@ void Spline::populateCurve() {
 
     auto beziers = splineCurve.toBeziers();
 
-    int nbBeziers = ts_bspline_num_control_points(beziers.data()) / splineCurve.order();
+    int nbBeziers = beziers.numControlPoints() / splineCurve.order();
     int nbCoordinate = splineCurve.order() * splineCurve.dimension();
 
     auto controlPoints = beziers.controlPoints();


### PR DESCRIPTION
BSpline::data() was removed from tinyspline api because of memory leak.
See msteinbeck/tinyspline#177. Fixes #380.