### PR TITLE
fixed bounding box calculation for cubic beziers

### DIFF
--- a/lckernel/cad/geometry/geobeziercubic.cpp
+++ b/lckernel/cad/geometry/geobeziercubic.cpp
@@ -30,8 +30,8 @@ const Area CubicBezier::boundingBox() const {
     std::vector<double> x_roots = lc::maths::Math::quadraticSolver({b.x()/a.x(), c.x()/a.x()});
     std::vector<double> y_roots = lc::maths::Math::quadraticSolver({b.y()/a.y(), b.y()/a.y()});
 
-    std::vector<double> x_{_pointA.x(), _pointB.x(),_pointC.x(), _pointD.x() };
-    std::vector<double> y_{_pointA.y(), _pointB.y(),_pointC.y(), _pointD.y() };
+    std::vector<double> x_{_pointA.x(), _pointD.x() };
+    std::vector<double> y_{_pointA.y(), _pointD.y() };
 
 
     for(const double tx_ : x_roots) {


### PR DESCRIPTION
The bounding box of the cubic Bézier curve does not contain the second and third control point.

See also the equivalent calculation for the bounding box of the quadratic Bézier curve, which does not contain the second control point.

A graphical interpretation can be found using the interactive tools from the [Primer on Béziers](https://pomax.github.io/bezierinfo/#boundingbox). The extremal points of the curve in the interval [0.0, 1.0] are always enclosed within the bounding box of the four control points. If one adds all four control points to the calculation, there is no need anymore to find the roots of the first derivative (but the result will be incorrect).