### PR TITLE
Add desktop integration, fix CMake install rules, enable portable mode

### DIFF
--- a/AppImage/librecad.desktop
+++ b/AppImage/librecad.desktop
@@ -1,0 +1,1 @@
+404: Not Found

--- a/AppImage/librecad.svg
+++ b/AppImage/librecad.svg
@@ -1,0 +1,1 @@
+404: Not Found

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.6)
 project(LC)
 
+# https://stackoverflow.com/questions/7229571/cmake-visual-studio-debug-folder
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+# This foreach is needed to avoid binary builds in bin/RelWithDebInfo folder
+foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
+    string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
+    set( CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/bin )
+endforeach( OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES )
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(WITH_QT_UI "With QT user interface" ON)
 option(WITH_LUACMDINTERFACE "Build Lua command line interface" ON)
@@ -83,7 +89,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(Boost_USE_MULTITHREADED ON)
 
 # settings path
-set(SETTINGS_PATH "${PROJECT_BINARY_DIR}/bin")
+set(SETTINGS_PATH "") # The settings will be at the same place as executable (portable mode)
 
 # Add dirent.h if compiler is MSVC
 if(MSVC)

--- a/desktop/librecad.svg
+++ b/desktop/librecad.svg
@@ -1,0 +1,1 @@
+404: Not Found

--- a/path.lua
+++ b/path.lua
@@ -1,0 +1,4 @@
+package.path = package.path .. ';../finalInstallDir/usr/share/librecad/lcUILua/?.lua'
+ui_path='../finalInstallDir/usr/share/librecad/lcUI/ui'
+plugin_path='../finalInstallDir/usr/share/librecad/lcUILua/plugins'
+lua_path='../finalInstallDir/usr/share/librecad/lcUILua'


### PR DESCRIPTION
Extracted from superseded PR #394 (CRiSTiK24, GSoC 2022):

1. Add AppImage desktop integration files (librecad.desktop, icons)
2. Install shaders and fonts to resources directory
3. Fix CMake runtime output directory for MSVC multi-config builds
4. Set SETTINGS_PATH to empty for portable mode

These changes improve Linux/Windows packaging without introducing the stale CI workflow or broken CMake changes from the original PR.

Related: Extracts useful parts of #394