### PR TITLE
CI: fix CodeQL cpp build (clone libdxfrw, fix empty file(COPY) destination)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,6 +73,12 @@ jobs:
         # Belt-and-suspenders: checkout already fetched submodules, but
         # re-run --init --recursive so any subsequently-added path is safe.
         git submodule update --init --recursive
+
+        # libdxfrw is not a submodule, so it has to be cloned explicitly the
+        # same way scripts/ubuntu-install/installDependenciesAndBuildRepo.sh
+        # does.  Without it `mkdir -p libdxfrw/release` just created an empty
+        # directory and cmake failed on the missing CMakeLists.txt.
+        git clone --branch LibreCAD_3 https://github.com/LibreCAD/libdxfrw
         mkdir -p libdxfrw/release
         pushd libdxfrw/release
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=On ..

--- a/lcUI/CMakeLists.txt
+++ b/lcUI/CMakeLists.txt
@@ -345,6 +345,10 @@ else()
 	install(TARGETS librecad DESTINATION "${FINAL_INSTALL_DIR}")
 	install(DIRECTORY "${CMAKE_SOURCE_DIR}/build/bin/lcUI/ui" DESTINATION "lcUI")
 endif()
-file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/default_ui_settings.json" DESTINATION "${SETTINGS_PATH}")
-file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/settings_schema.json" DESTINATION "${SETTINGS_PATH}")
+# SETTINGS_PATH is the runtime lookup path baked into the binary and is
+# intentionally empty for portable mode, so it can't be used as a build-time
+# copy destination (file(COPY) rejects an empty DESTINATION).  Copy next to
+# the executable instead, which is where portable mode expects them.
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/default_ui_settings.json" DESTINATION "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/settings_schema.json" DESTINATION "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 


### PR DESCRIPTION
Fixes two independent blockers that made the `cpp` leg of the CodeQL workflow fail on **every** run. Both predate this branch.

## 1. `libdxfrw` was never cloned

Every run died in the `Building` step with:

```
CMake Error: The source directory "/home/runner/work/LibreCAD_3/LibreCAD_3/libdxfrw" does not appear to contain CMakeLists.txt
```

`libdxfrw` is not a submodule — it is not in `.gitmodules`, and the runner only checks out `lckernel/nano-signal-slot`, `lckernel/tinyspline`, `persistence/libopencad`, `third_party/kaguya`, and `third_party/pybind11`. So `git submodule update --init --recursive` never populated it, `mkdir -p libdxfrw/release` just created an empty directory, and the following `cmake ..` had no source to configure.

Added the explicit clone that `scripts/ubuntu-install/installDependenciesAndBuildRepo.sh` — the documented Ubuntu build path — already performs:

```bash
git clone --branch LibreCAD_3 https://github.com/LibreCAD/libdxfrw
```

## 2. Empty `file(COPY)` DESTINATION from portable-mode `SETTINGS_PATH`

With the clone in place the build got as far as configuring LibreCAD itself, then failed:

```
CMake Error at lcUI/CMakeLists.txt:348 (file):
  file COPY given no DESTINATION
```

`SETTINGS_PATH` is the **runtime** settings lookup path compiled into the binary (`lckernel/build_constants.cpp.in` → `cad/storage/settings/modulesettings.cpp`). 556355ff deliberately changed it from `${PROJECT_BINARY_DIR}/bin` to `""` to enable portable mode.

`lcUI/CMakeLists.txt` reused that runtime constant as a **build-time** `file(COPY)` destination, and CMake rejects an empty `DESTINATION`.

The files are now copied to `CMAKE_RUNTIME_OUTPUT_DIRECTORY` (`${CMAKE_BINARY_DIR}/bin`) — where the executable is built, and therefore where portable mode looks for them. This restores the destination used before 4eb7a9cc while leaving `SETTINGS_PATH` empty so portable mode is preserved.

## Verification

- Confirmed the `does not appear to contain CMakeLists.txt` failure is the root cause across multiple historical runs, not just the latest.
- Confirmed `libdxfrw` is absent from `.gitmodules` and from the submodule list the runner actually checks out.
- Confirmed `git clone --branch LibreCAD_3 https://github.com/LibreCAD/libdxfrw` produces `libdxfrw/CMakeLists.txt`, exactly the path the subsequent `cmake ..` resolves from `libdxfrw/release`.
- Confirmed the workflow's apt dependency list already matches `installDependenciesAndBuildRepo.sh`, so no dependency changes are needed.
- The first commit was verified by CI itself: the run on it got past `libdxfrw` entirely and failed only at the `lcUI` error above.
- Verified locally that configuring no longer emits `file COPY given no DESTINATION`, and that `default_ui_settings.json` and `settings_schema.json` are copied next to the executable.

Both changes are build/CI only; no application source is touched.
