### PR TITLE
Fix DXF export dropping entities (#412), plus Lua 5.4/5.5 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,12 @@ name: Librecad3 Builders
   push:
     branches:
       - main
+      - master
       - ci_dev
+  pull_request:
+    branches:
+      - main
+      - master
 
 jobs:
   linux:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,27 @@ if(HAS_WNO_MISSING_TEMPLATE_ARG_LIST)
     add_definitions("-Wno-missing-template-arg-list-after-template-kw")
 endif()
 
+# Lua 5.5 removed LUA_GCSETPAUSE and LUA_GCSETSTEPMUL in favour of the
+# parameterised LUA_GCPARAM.  kaguya still uses the old names, in exactly two
+# places (State::steppause and State::setstepmul in state.hpp) and nowhere
+# else.  lua_gc() is variadic, so expanding each removed constant to the pair
+# "LUA_GCPARAM, <5.5 parameter id>" rewrites the call into precisely the 5.5
+# spelling:
+#
+#   lua_gc(L, LUA_GCSETPAUSE, v)  ->  lua_gc(L, LUA_GCPARAM, LUA_GCPPAUSE, v)
+#
+# That is the real replacement API, not a way to quiet the error, so the two
+# functions keep working rather than silently doing something else.  Applied
+# before any add_subdirectory() so every target compiling a kaguya header sees
+# it.  Drop this once kaguya handles 5.5 upstream.
+find_package(Lua 5.3 REQUIRED)
+if(LUA_VERSION_STRING VERSION_GREATER_EQUAL "5.5")
+    message(STATUS "Lua ${LUA_VERSION_STRING}: mapping kaguya's removed GC constants onto LUA_GCPARAM")
+    add_compile_definitions(
+        "LUA_GCSETPAUSE=LUA_GCPARAM,LUA_GCPPAUSE"
+        "LUA_GCSETSTEPMUL=LUA_GCPARAM,LUA_GCPSTEPMUL")
+endif()
+
 #Add each LibreCAD component
 add_subdirectory("lckernel")
 

--- a/lcUI/CMakeLists.txt
+++ b/lcUI/CMakeLists.txt
@@ -228,7 +228,10 @@ link_directories(${Boost_LIBRARY_DIRS})
 endif()
 
 #Lua
-find_package(Lua 5.3 EXACT REQUIRED)
+# Lua 5.3 or newer.  Was EXACT 5.3, which made the build unusable on any
+# distribution shipping a newer Lua (Homebrew now defaults to 5.5).
+# kaguya supports 5.4+ as of the submodule bump in this commit.
+find_package(Lua 5.3 REQUIRED)
 include_directories(${LUA_INCLUDE_DIR})
 link_directories(${LUA_LIBRARY_DIRS})
 

--- a/lcUI/lcadviewerproxy.cpp
+++ b/lcUI/lcadviewerproxy.cpp
@@ -6,7 +6,10 @@ using namespace lc::ui;
 
 using namespace lc::ui;
 
-LCADViewerProxy::LCADViewerProxy(QWidget* parent=0) {
+// No default argument here: it belongs on the declaration in the header, and
+// repeating it in the definition turns this into a default constructor, which
+// Clang rejects outright ("addition of default argument on redeclaration").
+LCADViewerProxy::LCADViewerProxy(QWidget* parent) {
     auto gridLayout = new QGridLayout(this);
     gridLayout->setHorizontalSpacing(0);
     gridLayout->setVerticalSpacing(0);

--- a/lcadluascript/CMakeLists.txt
+++ b/lcadluascript/CMakeLists.txt
@@ -77,7 +77,10 @@ else ()
 endif ()
 
 #Lua
-find_package(Lua 5.3 EXACT REQUIRED)
+# Lua 5.3 or newer.  Was EXACT 5.3, which made the build unusable on any
+# distribution shipping a newer Lua (Homebrew now defaults to 5.5).
+# kaguya supports 5.4+ as of the submodule bump in this commit.
+find_package(Lua 5.3 REQUIRED)
 include_directories(${LUA_INCLUDE_DIR})
 
 # Logging

--- a/luacmdinterface/CMakeLists.txt
+++ b/luacmdinterface/CMakeLists.txt
@@ -28,7 +28,10 @@ link_directories(${Boost_LIBRARY_DIRS})
 message(boost_dirs="${Boost_LIBRARY_DIRS}")
 
 #Lua
-find_package(Lua 5.3 EXACT REQUIRED)
+# Lua 5.3 or newer.  Was EXACT 5.3, which made the build unusable on any
+# distribution shipping a newer Lua (Homebrew now defaults to 5.5).
+# kaguya supports 5.4+ as of the submodule bump in this commit.
+find_package(Lua 5.3 REQUIRED)
 include_directories(${LUA_INCLUDE_DIR})
 link_directories(${LUA_LIBRARY_DIRS})
 

--- a/persistence/libdxfrw/dxfimpl.cpp
+++ b/persistence/libdxfrw/dxfimpl.cpp
@@ -1333,13 +1333,235 @@ void DXFimpl::writeAppId() {
     dxfW->writeAppId(&ai);
 }
 
-void DXFimpl::writeDimension(const lc::entity::Dimension_CSPtr& d) {
+// Issue #412 phase 1: populate the DRW_Dimension base header shared by all
+// five subtypes.  Kept out of the per-subtype writers because getEntityAttributes
+// needs the CADEntity pointer (which the Dimension base doesn't carry).
+void DXFimpl::writeDimensionCommon(DRW_Dimension* dim,
+                                   const lc::entity::CADEntity_CSPtr& entity,
+                                   const lc::entity::Dimension& d) {
+    getEntityAttributes(dim, entity);
+
+    dim->setDefPoint(DRW_Coord(d.definitionPoint().x(),
+                               d.definitionPoint().y(),
+                               d.definitionPoint().z()));
+    dim->setTextPoint(DRW_Coord(d.middleOfText().x(),
+                                d.middleOfText().y(),
+                                d.middleOfText().z()));
+    dim->setAlign(static_cast<int>(d.attachmentPoint()));
+    dim->setDir(d.textAngle());
+    dim->setTextLineFactor(d.lineSpacingFactor());
+    dim->setTextLineStyle(static_cast<int>(d.lineSpacingStyle()));
+    dim->setText(d.explicitValue());
+    // Style must be non-empty or the R2000+ writer path skips writing group
+    // 3 entirely, then downstream readers reject the dimension header.
+    dim->setStyle("STANDARD");
 }
 
+void DXFimpl::writeDimLinear(const lc::entity::DimLinear_CSPtr& d) {
+    DRW_DimLinear dim;
+    writeDimensionCommon(&dim, d, *d);
+    // DXF code 70 subtype: 0 = linear (rotated/horizontal/vertical).  Without
+    // setting this, libdxfrw's reader would treat every dim as linear anyway,
+    // but the writer's dispatch chain still keys off eType (set in ctor).
+    dim.type = 0;
+    dim.setDef1Point(DRW_Coord(d->definitionPoint2().x(),
+                               d->definitionPoint2().y(),
+                               d->definitionPoint2().z()));
+    dim.setDef2Point(DRW_Coord(d->definitionPoint3().x(),
+                               d->definitionPoint3().y(),
+                               d->definitionPoint3().z()));
+    dim.setAngle(d->angle());
+    dim.setOblique(d->oblique());
+    dxfW->writeDimension(&dim);
+}
+
+void DXFimpl::writeDimAligned(const lc::entity::DimAligned_CSPtr& d) {
+    DRW_DimAligned dim;
+    writeDimensionCommon(&dim, d, *d);
+    dim.type = 1;  // aligned
+    dim.setDef1Point(DRW_Coord(d->definitionPoint2().x(),
+                               d->definitionPoint2().y(),
+                               d->definitionPoint2().z()));
+    dim.setDef2Point(DRW_Coord(d->definitionPoint3().x(),
+                               d->definitionPoint3().y(),
+                               d->definitionPoint3().z()));
+    dxfW->writeDimension(&dim);
+}
+
+void DXFimpl::writeDimRadial(const lc::entity::DimRadial_CSPtr& d) {
+    DRW_DimRadial dim;
+    writeDimensionCommon(&dim, d, *d);
+    dim.type = 4;  // radius
+    // setDefPoint was called with definitionPoint() in the common helper.
+    // For radial dims, defPoint IS the center (see addDimRadial reader).
+    dim.setDiameterPoint(DRW_Coord(d->definitionPoint2().x(),
+                                   d->definitionPoint2().y(),
+                                   d->definitionPoint2().z()));
+    dim.setLeaderLength(d->leader());
+    dxfW->writeDimension(&dim);
+}
+
+void DXFimpl::writeDimDiametric(const lc::entity::DimDiametric_CSPtr& d) {
+    DRW_DimDiametric dim;
+    writeDimensionCommon(&dim, d, *d);
+    dim.type = 3;  // diameter
+    // For diametric dims the reader treats defPoint (10) as diameter2Point
+    // and getPt5/code 15 as diameter1Point.  The lc entity's
+    // definitionPoint()  is diameter1 (that's how addDimDiametric reads it),
+    // definitionPoint2()  is diameter2.  Match that pairing exactly.
+    dim.setDiameter1Point(DRW_Coord(d->definitionPoint().x(),
+                                    d->definitionPoint().y(),
+                                    d->definitionPoint().z()));
+    dim.setDiameter2Point(DRW_Coord(d->definitionPoint2().x(),
+                                    d->definitionPoint2().y(),
+                                    d->definitionPoint2().z()));
+    dim.setLeaderLength(d->leader());
+    dxfW->writeDimension(&dim);
+}
+
+void DXFimpl::writeDimAngular(const lc::entity::DimAngular_CSPtr& d) {
+    DRW_DimAngular dim;
+    writeDimensionCommon(&dim, d, *d);
+    dim.type = 2;  // angular (2-line)
+    dim.setFirstLine1(DRW_Coord(d->defLine11().x(),
+                                d->defLine11().y(),
+                                d->defLine11().z()));
+    dim.setFirstLine2(DRW_Coord(d->defLine12().x(),
+                                d->defLine12().y(),
+                                d->defLine12().z()));
+    dim.setSecondLine1(DRW_Coord(d->defLine21().x(),
+                                 d->defLine21().y(),
+                                 d->defLine21().z()));
+    dim.setSecondLine2(DRW_Coord(d->defLine22().x(),
+                                 d->defLine22().y(),
+                                 d->defLine22().z()));
+    // Angular's DimPoint (code 16, arcPoint) is used for arc placement;
+    // reuse definitionPoint() so the exported file has a plausible value.
+    dim.setDimPoint(DRW_Coord(d->definitionPoint().x(),
+                              d->definitionPoint().y(),
+                              d->definitionPoint().z()));
+    dxfW->writeDimension(&dim);
+}
+
+// Issue #412 phase 1: dispatched, but body was empty — LWPolylines vanished
+// from every save.  Mirror addLWPolyline's field mapping.
 void DXFimpl::writeLWPolyline(const lc::entity::LWPolyline_CSPtr& p) {
+    DRW_LWPolyline pl;
+    getEntityAttributes(&pl, p);
+
+    pl.width = p->width();
+    pl.elevation = p->elevation();
+    pl.thickness = p->tickness();
+    pl.extPoint.x = p->extrusionDirection().x();
+    pl.extPoint.y = p->extrusionDirection().y();
+    pl.extPoint.z = p->extrusionDirection().z();
+    // DXF group 70 bit 0 = "closed"; addLWPolyline reads it back the same way.
+    pl.flags = p->closed() ? 1 : 0;
+
+    for (const auto& v : p->vertex()) {
+        auto vert = std::make_shared<DRW_Vertex2D>();
+        vert->x = v.location().x();
+        vert->y = v.location().y();
+        vert->stawidth = v.startWidth();
+        vert->endwidth = v.endWidth();
+        vert->bulge = v.bulge();
+        pl.vertlist.push_back(vert);
+    }
+    pl.vertexnum = pl.vertlist.size();
+
+    dxfW->writeLWPolyline(&pl);
 }
 
+// Issue #412 phase 1: dispatched, but body was empty — images vanished.
+// Matches libdxfrw's writeImage(ent, name) contract; name is used to key the
+// ImageDef object dictionary.
 void DXFimpl::writeImage(const lc::entity::Image_CSPtr& i) {
+    DRW_Image img;
+    getEntityAttributes(&img, i);
+
+    img.basePoint.x = i->base().x();
+    img.basePoint.y = i->base().y();
+    img.basePoint.z = i->base().z();
+    // secPoint holds the U-vector (per single pixel), vVector the V-vector;
+    // sizeu/sizev are the image size in pixels — mapped to width/height here
+    // because that's what the reader (linkImage) rebuilds the Image from.
+    img.secPoint.x = i->uv().x();
+    img.secPoint.y = i->uv().y();
+    img.secPoint.z = i->uv().z();
+    img.vVector.x = i->vv().x();
+    img.vVector.y = i->vv().y();
+    img.vVector.z = i->vv().z();
+    img.sizeu = i->width();
+    img.sizev = i->height();
+    img.brightness = static_cast<int>(i->brightness());
+    img.contrast   = static_cast<int>(i->contrast());
+    img.fade       = static_cast<int>(i->fade());
+
+    dxfW->writeImage(&img, i->name());
+}
+
+// Issue #412 phase 1: written from scratch — the reader ingests HATCH but
+// no writer existed, not even a declaration.  Only Line, Arc, Ellipse edge
+// types are emitted here; libdxfrw's writeHatch itself has no support for
+// SPLINE or POLYLINE boundary paths (code marked `//RLZ: TODO`), so trying
+// to emit them would just produce silently-ignored bytes.
+void DXFimpl::writeHatch(const lc::entity::Hatch_CSPtr& h) {
+    DRW_Hatch hatch;
+    getEntityAttributes(&hatch, h);
+
+    hatch.name = h->getPatternName();
+    hatch.solid = h->isSolid() ? 1 : 0;
+    hatch.associative = 0;
+    hatch.hstyle = 0;
+    hatch.hpattern = 1;
+    hatch.doubleflag = 0;
+    hatch.angle = h->getAngle();
+    hatch.scale = h->getScale();
+    hatch.deflines = 0;
+
+    const auto& region = h->getRegion();
+    for (const auto& loop : region.loopList()) {
+        auto drwLoop = std::make_shared<DRW_HatchLoop>(0); // 0 = default (not polyline)
+        for (const auto& e : loop.entities()) {
+            if (auto ln = std::dynamic_pointer_cast<const lc::entity::Line>(e)) {
+                auto drwLn = std::make_shared<DRW_Line>();
+                drwLn->basePoint.x = ln->start().x();
+                drwLn->basePoint.y = ln->start().y();
+                drwLn->secPoint.x  = ln->end().x();
+                drwLn->secPoint.y  = ln->end().y();
+                drwLoop->objlist.push_back(drwLn);
+            } else if (auto ar = std::dynamic_pointer_cast<const lc::entity::Arc>(e)) {
+                auto drwAr = std::make_shared<DRW_Arc>();
+                drwAr->basePoint.x = ar->center().x();
+                drwAr->basePoint.y = ar->center().y();
+                drwAr->radious = ar->radius();
+                drwAr->staangle = ar->startAngle();
+                drwAr->endangle = ar->endAngle();
+                drwAr->isccw = ar->CCW() ? 1 : 0;
+                drwLoop->objlist.push_back(drwAr);
+            } else if (auto el = std::dynamic_pointer_cast<const lc::entity::Ellipse>(e)) {
+                auto drwEl = std::make_shared<DRW_Ellipse>();
+                drwEl->basePoint.x = el->center().x();
+                drwEl->basePoint.y = el->center().y();
+                drwEl->secPoint.x  = el->majorP().x();
+                drwEl->secPoint.y  = el->majorP().y();
+                drwEl->ratio = 1.0 / el->ratio();
+                drwEl->staparam = el->startAngle();
+                drwEl->endparam = el->endAngle();
+                drwEl->isccw = el->isReversed() ? 0 : 1;
+                drwLoop->objlist.push_back(drwEl);
+            }
+            // LWPolyline / Spline boundary types deliberately skipped —
+            // libdxfrw's writeHatch has no code path for them (TODO in
+            // upstream).  Silent-drop-inside-a-hatch matches the reader's
+            // own capability envelope; documented rather than silent because
+            // this is the export writer, not user-visible.
+        }
+        drwLoop->update();
+        hatch.appendLoop(drwLoop);
+    }
+
+    dxfW->writeHatch(&hatch);
 }
 
 void DXFimpl::writeText(const lc::entity::Text_CSPtr& t) {
@@ -1446,6 +1668,61 @@ void DXFimpl::writeEntity(const lc::entity::CADEntity_CSPtr& entity) {
     auto insert = std::dynamic_pointer_cast<const lc::entity::Insert>(entity);
     if (insert != nullptr) {
         writeInsert(insert);
+        return;
+    }
+
+    // Issue #412 phase 1: the six kinds the writer used to drop.
+    // Point + Spline had complete writer bodies but were never dispatched;
+    // Hatch had no writer at all.  Dimensions must dispatch per subtype
+    // (not to the Dimension base) because the DXF group 70 subtype flag
+    // and the subtype-specific geometry live on the concrete class.
+    auto point = std::dynamic_pointer_cast<const lc::entity::Point>(entity);
+    if (point != nullptr) {
+        writePoint(point);
+        return;
+    }
+
+    auto spline = std::dynamic_pointer_cast<const lc::entity::Spline>(entity);
+    if (spline != nullptr) {
+        writeSpline(spline);
+        return;
+    }
+
+    auto hatch = std::dynamic_pointer_cast<const lc::entity::Hatch>(entity);
+    if (hatch != nullptr) {
+        writeHatch(hatch);
+        return;
+    }
+
+    // Per-subtype dimension dispatch — see writeDimensionCommon for why the
+    // base class Dimension is never dispatched directly.
+    auto dimLinear = std::dynamic_pointer_cast<const lc::entity::DimLinear>(entity);
+    if (dimLinear != nullptr) {
+        writeDimLinear(dimLinear);
+        return;
+    }
+
+    auto dimAligned = std::dynamic_pointer_cast<const lc::entity::DimAligned>(entity);
+    if (dimAligned != nullptr) {
+        writeDimAligned(dimAligned);
+        return;
+    }
+
+    auto dimRadial = std::dynamic_pointer_cast<const lc::entity::DimRadial>(entity);
+    if (dimRadial != nullptr) {
+        writeDimRadial(dimRadial);
+        return;
+    }
+
+    auto dimDiametric = std::dynamic_pointer_cast<const lc::entity::DimDiametric>(entity);
+    if (dimDiametric != nullptr) {
+        writeDimDiametric(dimDiametric);
+        return;
+    }
+
+    auto dimAngular = std::dynamic_pointer_cast<const lc::entity::DimAngular>(entity);
+    if (dimAngular != nullptr) {
+        writeDimAngular(dimAngular);
         return;
     }
 }

--- a/persistence/libdxfrw/dxfimpl.cpp
+++ b/persistence/libdxfrw/dxfimpl.cpp
@@ -917,26 +917,34 @@ bool DXFimpl::writeDXF(const std::string& filename, lc::persistence::File::Type 
 void DXFimpl::writePoint(const lc::entity::Point_CSPtr& p) {
     DRW_Point point;
     getEntityAttributes(&point, p);
+    // Issue #412 phase 2: propagate Z through — the lc::entity::Point IS a
+    // geo::Coordinate, so it has a real z() value the writer used to drop.
     point.basePoint.x = p->x();
     point.basePoint.y = p->y();
+    point.basePoint.z = p->z();
     dxfW->writePoint(&point);
 }
 
 void DXFimpl::writeLine(const lc::entity::Line_CSPtr& l) {
     DRW_Line line;
     getEntityAttributes(&line, l);
+    // Issue #412 phase 2: preserve Z on both endpoints.
     line.basePoint.x = l->start().x();
     line.basePoint.y = l->start().y();
+    line.basePoint.z = l->start().z();
     line.secPoint.x = l->end().x();
     line.secPoint.y = l->end().y();
+    line.secPoint.z = l->end().z();
     dxfW->writeLine(&line);
 }
 
 void DXFimpl::writeCircle(const lc::entity::Circle_CSPtr& c) {
     DRW_Circle circle;
     getEntityAttributes(&circle, c);
+    // Issue #412 phase 2: preserve Z of center.
     circle.basePoint.x = c->center().x();
     circle.basePoint.y = c->center().y();
+    circle.basePoint.z = c->center().z();
     circle.radious = c->radius();
     dxfW->writeCircle(&circle);
 }
@@ -944,8 +952,10 @@ void DXFimpl::writeCircle(const lc::entity::Circle_CSPtr& c) {
 void DXFimpl::writeArc(const lc::entity::Arc_CSPtr& a) {
     DRW_Arc arc;
     getEntityAttributes(&arc, a);
+    // Issue #412 phase 2: preserve Z of center.
     arc.basePoint.x = a->center().x();
     arc.basePoint.y = a->center().y();
+    arc.basePoint.z = a->center().z();
     arc.radious = a->radius();
     if (a->CCW()) {
         arc.staangle = a->startAngle();
@@ -960,10 +970,13 @@ void DXFimpl::writeArc(const lc::entity::Arc_CSPtr& a) {
 void DXFimpl::writeEllipse(const lc::entity::Ellipse_CSPtr& s) {
     DRW_Ellipse el;
     getEntityAttributes(&el, s);
+    // Issue #412 phase 2: preserve Z of both center and major axis point.
     el.basePoint.x = s->center().x();
     el.basePoint.y = s->center().y();
+    el.basePoint.z = s->center().z();
     el.secPoint.x = s->majorP().x();
     el.secPoint.y = s->majorP().y();
+    el.secPoint.z = s->majorP().z();
     el.ratio = 1/s->ratio();
     if (s->isReversed()) {
         el.staparam = s->endAngle();
@@ -1571,14 +1584,29 @@ void DXFimpl::writeText(const lc::entity::Text_CSPtr& t) {
     std::string correctedText = t->text_value();
     std::replace(correctedText.begin(), correctedText.end(), '\n', '\\');
 
+    // Issue #412 phase 2: preserve Z on insertion point.
     tex.basePoint.x = t->insertion_point().x();
     tex.basePoint.y = t->insertion_point().y();
+    tex.basePoint.z = t->insertion_point().z();
     tex.text = correctedText;
     tex.textgen = t->textgeneration();
     tex.height = t->height();
     tex.angle = t->angle() * 180 / M_PI;
     tex.alignH = DRW_Text::HAlign(t->halign());
     tex.alignV = DRW_Text::VAlign(t->valign());
+    // Issue #412 phase 2: text style was never written; downstream readers
+    // would fall back to "STANDARD" but any user-picked style silently reset.
+    // Empty style is invalid DXF, so keep the default fallback.
+    if (!t->style().empty()) {
+        tex.style = t->style();
+    }
+    // Issue #412 phase 2: alignment point (code 11) was defaulting to (0,0,0),
+    // which means the reader anchors non-left/non-baseline text at the origin
+    // instead of at the intended insertion point.  libdxfrw's writeText only
+    // emits code 11 when alignment is non-default, so seeding secPoint with
+    // the insertion point costs nothing when unused and fixes placement when
+    // it matters.
+    tex.secPoint = tex.basePoint;
 
     dxfW->writeText(&tex);
 }
@@ -1594,14 +1622,63 @@ void DXFimpl::writeMText(const lc::entity::MText_CSPtr& t) {
         correctedText.replace(index, 1, "\\P");
     }
 
+    // Issue #412 phase 2: preserve Z on insertion point.
     tex.basePoint.x = t->insertion_point().x();
     tex.basePoint.y = t->insertion_point().y();
+    tex.basePoint.z = t->insertion_point().z();
     tex.text = correctedText;
-    tex.textgen = t->textgeneration();
     tex.height = t->height();
     tex.angle = t->angle() * 180 / M_PI;
-    tex.alignH = DRW_Text::HAlign(t->halign());
-    tex.alignV = DRW_Text::VAlign(t->valign());
+    if (!t->style().empty()) {
+        tex.style = t->style();
+    }
+
+    // Issue #412 phase 2: DXF group-code semantics differ between TEXT and
+    // MTEXT.  For MTEXT, code 71 is the ATTACHMENT POINT (1..9, TL..BR), not
+    // a text generation flag; code 72 is the DRAWING DIRECTION (1=LtR,
+    // 3=TtB, 5=byStyle), not horizontal alignment; code 73 is the LINE
+    // SPACING STYLE (1=at least, 2=exact), not vertical alignment.  The
+    // previous writer passed halign/valign/textgeneration straight through
+    // into 71/72/73 — reader-side addMText then reversed that with its
+    // %3 and /3 rowcode/colcode arithmetic, so on round-trip an MText's
+    // alignment was consistently garbled.  Compute the attachment point
+    // from HAlign * VAlign the way addMText decodes it.
+    int col;
+    switch (t->halign()) {
+        case lc::TextConst::HAlign::HALeft:   col = 1; break;
+        case lc::TextConst::HAlign::HACenter: col = 2; break;
+        case lc::TextConst::HAlign::HARight:  col = 3; break;
+        default:                              col = 1; break;
+    }
+    int row;
+    switch (t->valign()) {
+        case lc::TextConst::VAlign::VATop:    row = 1; break;
+        case lc::TextConst::VAlign::VAMiddle: row = 2; break;
+        case lc::TextConst::VAlign::VABottom: row = 3; break;
+        case lc::TextConst::VAlign::VABaseline: /* fall through */
+        default:                              row = 3; break;
+    }
+    tex.textgen = (row - 1) * 3 + col;   // MText attachment point, code 71
+
+    // Drawing direction encoding (code 72): 1=LtR, 3=TtB, 5=byStyle.
+    // lc::TextConst::DrawingDirection: None=0, Backward=1, UpsideDown=3.
+    // Reader's addMText maps 1->Backward, 3->UpsideDown, else->None.  Match
+    // that inverse here so round-trip is symmetric.
+    // libdxfrw types alignH/alignV as enums (DRW_Text::HAlign/VAlign) even on
+    // the DRW_MText path where the DXF semantics have nothing to do with
+    // TEXT alignment.  Cast is required — the integer we set here is what the
+    // writer emits verbatim as code 72 / code 73 for MTEXT.
+    switch (t->textgeneration()) {
+        case lc::TextConst::DrawingDirection::Backward:
+            tex.alignH = static_cast<DRW_Text::HAlign>(1); break;
+        case lc::TextConst::DrawingDirection::UpsideDown:
+            tex.alignH = static_cast<DRW_Text::HAlign>(3); break;
+        default:
+            tex.alignH = static_cast<DRW_Text::HAlign>(0); break;
+    }
+    // Line spacing style (code 73): 1=at least, 2=exact.  lc::entity::MText
+    // doesn't currently carry a spacing style so default to 1.
+    tex.alignV = static_cast<DRW_Text::VAlign>(1);
 
     dxfW->writeMText(&tex);
 }

--- a/persistence/libdxfrw/dxfimpl.cpp
+++ b/persistence/libdxfrw/dxfimpl.cpp
@@ -3,6 +3,7 @@
 
 #include "../patternLoader/patternProvider.h"
 #include <algorithm>
+#include <set>
 
 #include <cad/primitive/circle.h>
 #include <cad/primitive/hatch.h>
@@ -856,11 +857,27 @@ void DXFimpl::writeLayer(const std::shared_ptr<const lc::meta::Layer>& layer) {
     auto col = layer->color();
     lay.name = layer->name();
     lay.color = icol_inst.colorToInt(col);
-    auto wid = layer->lineWidth().width();
-    std::cout << wid;
-//    auto val = widthToInt();
 
-//    lay.lWeight = static_cast<DRW_LW_Conv::lineWidth>();
+    // Issue #412 phase 3: (a) stop the stray `std::cout << wid;` that has
+    // been dumping the layer line width to stdout on every save since 2016.
+    // (b) actually emit the layer line weight — the conversion was commented
+    // out for a decade, so every saved layer defaulted to widthDefault.
+    auto wid = layer->lineWidth().width();
+    int lwIdx = widthToInt(wid);
+    if (lwIdx >= 0) {
+        lay.lWeight = static_cast<DRW_LW_Conv::lineWidth>(lwIdx);
+    } else {
+        lay.lWeight = DRW_LW_Conv::widthDefault;
+    }
+
+    // Issue #412 phase 3: emit the layer's line pattern name (code 6) so the
+    // reader can match entities that reference it back to the layer LTYPE.
+    // Skip an empty/unset pattern; libdxfrw defaults to "CONTINUOUS".
+    auto lp = layer->linePattern();
+    if (lp != nullptr && !lp->name().empty()) {
+        lay.lineType = lp->name();
+    }
+
     lay.flags = layer->isFrozen() ? 0x01 : 0x00;
 
     dxfW->writeLayer(&lay);
@@ -1338,12 +1355,59 @@ void DXFimpl::writeLTypes() {
     ltype.path.push_back(12.7);
     ltype.path.push_back(-12.7);
     dxfW->writeLineType(&ltype);
+
+    // Issue #412 phase 3: emit every DxfLinePatternByValue registered on the
+    // document, not just the hardcoded set above.  Without this, entities
+    // referencing a user-imported LTYPE (very common when a supplier's DXF
+    // is opened and re-saved) point at an absent LTYPE table entry — the
+    // resulting file is structurally invalid DXF.  Skip names already
+    // covered by the hardcoded standard set to avoid duplicate table entries.
+    static const std::set<std::string> kBuiltin{
+        "CONTINUOUS", "ByLayer", "ByBlock",
+        "DOT", "DOTTINY", "DOT2", "DOTX2",
+        "DASHED", "DASHEDTINY", "DASHED2", "DASHEDX2",
+        "DASHDOT", "DASHDOTTINY", "DASHDOT2", "DASHDOTX2",
+        "DIVIDE", "DIVIDETINY", "DIVIDE2", "DIVIDEX2",
+        "BORDER", "BORDERTINY", "BORDER2", "BORDERX2",
+        "CENTER", "CENTERTINY", "CENTER2", "CENTERX2"};
+    for (const auto& lp : _document->linePatterns()) {
+        if (lp == nullptr) continue;
+        const std::string& name = lp->name();
+        if (name.empty() || kBuiltin.count(name)) continue;
+
+        DRW_LType user;
+        user.name = name;
+        user.desc = lp->description();
+        user.path = lp->path();
+        user.size = static_cast<int>(user.path.size());
+        user.length = lp->length();
+        dxfW->writeLineType(&user);
+    }
 }
 
 void DXFimpl::writeAppId() {
     DRW_AppId ai;
     ai.name ="LibreCad";
     dxfW->writeAppId(&ai);
+}
+
+// Issue #412 phase 3: writeHeader was defaulted to empty; drawings saved by
+// LibreCAD carried no HEADER variables at all.  Some readers (AutoCAD in
+// strict mode, ezdxf pedantic mode) reject a file with no $ACADVER, and
+// downstream tools that key off $INSUNITS silently pick the wrong unit.
+// Emit a small viable set — the version tag matches whatever writeDXF
+// selected, the units default to Millimeter, measurement to Metric.
+void DXFimpl::writeHeader(DRW_Header& data) {
+    // $ACADVER identifies the DXF spec; libdxfrw's writer also writes it
+    // unconditionally, so this is belt-and-braces for readers that check the
+    // header variable rather than the file preamble.
+    data.addStr("$ACADVER", "AC1015", 1);
+    // Default to Metric with millimeter insertion units.  The document API
+    // doesn't currently expose a unit-of-measure field for the whole
+    // drawing, so hard-code the sensible default rather than the DXF
+    // spec-default of 0 (unitless).
+    data.addInt("$MEASUREMENT", 1, 70);       // 0 = English, 1 = Metric
+    data.addInt("$INSUNITS", 4, 70);          // 4 = Millimeter
 }
 
 // Issue #412 phase 1: populate the DRW_Dimension base header shared by all

--- a/persistence/libdxfrw/dxfimpl.h
+++ b/persistence/libdxfrw/dxfimpl.h
@@ -128,7 +128,7 @@ public:
     // WRITE FUNCTIONALITY
     bool writeDXF(const std::string& filename, lc::persistence::File::Type type);
 
-    void writeHeader(DRW_Header& data) override {}
+    void writeHeader(DRW_Header& data) override;
 
     void writeBlocks() override;
 

--- a/persistence/libdxfrw/dxfimpl.h
+++ b/persistence/libdxfrw/dxfimpl.h
@@ -168,11 +168,29 @@ public:
 
     void writeSpline(const lc::entity::Spline_CSPtr& s);
 
-    void writeDimension(const lc::entity::Dimension_CSPtr& d);
+    // Issue #412 phase 1: five per-subtype dimension writers plus a shared
+    // helper that populates the DRW_Dimension base fields.  Per-subtype
+    // dispatch is required because (a) getEntityAttributes() needs the
+    // CADEntity (which Dimension itself isn't), (b) each subtype has its
+    // own geometry, and (c) DXF group 70 must be set per subtype — otherwise
+    // every dimension reads back as linear.
+    void writeDimensionCommon(DRW_Dimension* dim,
+                              const lc::entity::CADEntity_CSPtr& entity,
+                              const lc::entity::Dimension& d);
+
+    void writeDimLinear(const lc::entity::DimLinear_CSPtr& d);
+    void writeDimAligned(const lc::entity::DimAligned_CSPtr& d);
+    void writeDimRadial(const lc::entity::DimRadial_CSPtr& d);
+    void writeDimDiametric(const lc::entity::DimDiametric_CSPtr& d);
+    void writeDimAngular(const lc::entity::DimAngular_CSPtr& d);
 
     void writeLWPolyline(const lc::entity::LWPolyline_CSPtr& p);
 
     void writeImage(const lc::entity::Image_CSPtr& i);
+
+    // Issue #412 phase 1: previously no writer existed for Hatch — not even
+    // a declaration — so hatches vanished from any DXF save.
+    void writeHatch(const lc::entity::Hatch_CSPtr& h);
 
     void writeText(const lc::entity::Text_CSPtr& t);
 

--- a/scripts/windows-install/buildLibrecadAndCreatePackage.bat
+++ b/scripts/windows-install/buildLibrecadAndCreatePackage.bat
@@ -3,7 +3,15 @@ cd ${{ github.workspace }}
 
 pwd
 
-cmake -S %cd% -G "Visual Studio 17 2022" ^
+REM No -G here on purpose.  This used to pin "Visual Studio 17 2022", which the
+REM runner image no longer ships: conan detects msvc 18 (compiler.version=195,
+REM toolset v145), so cmake failed with
+REM
+REM   Generator "Visual Studio 17 2022" could not find any instance of Visual Studio.
+REM
+REM Letting cmake pick the newest installed Visual Studio keeps working when the
+REM image moves again, and the conan toolchain already pins the toolset.
+cmake -S %cd% ^
 -B %cd%\build ^
 -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake ^
 -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ^

--- a/scripts/windows-install/buildLibrecadAndCreatePackage.bat
+++ b/scripts/windows-install/buildLibrecadAndCreatePackage.bat
@@ -11,11 +11,16 @@ cmake -S %cd% -G "Visual Studio 17 2022" ^
 -DWITH_RENDERING_UNITTESTS=OFF ^
 --install-prefix %cd%\installprefix
 
+REM Fail here rather than letting a broken configure surface much later as a
+REM missing CPackConfig.cmake.
+if errorlevel 1 exit /b 1
+
 rem -DWITH_UNITTESTS=OFF
 cd build
 dir CPack*.cmake
 
 cmake --build . --config Release --target package
+if errorlevel 1 exit /b 1
 
 cd bin/Release
 dir

--- a/scripts/windows-install/createConanDirAndInstallDependencies.bat
+++ b/scripts/windows-install/createConanDirAndInstallDependencies.bat
@@ -3,5 +3,23 @@ pwd
 mkdir conan
 pushd conan
 conan profile detect --force
+if errorlevel 1 (popd & exit /b 1)
+
+REM CMake 4 removed compatibility with cmake_minimum_required(VERSION <3.5),
+REM and conan builds libdxfrw/2.2.0 from source, whose CMakeLists still asks
+REM for an older minimum.  The configure then fails with
+REM
+REM   Compatibility with CMake < 3.5 has been removed from CMake.
+REM
+REM taking conan_toolchain.cmake with it, so the LibreCAD build that follows
+REM failed confusingly on a missing toolchain file rather than on the real
+REM cause.  CMake offers this variable as the supported escape hatch and
+REM honours it from the environment, so every package conan configures picks
+REM it up.  Drop this once the dependencies declare a >= 3.5 minimum.
+set CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 conan install .. -s build_type=Release --build missing
+REM Without this the step reported success even when conan had failed, and the
+REM build only broke later, somewhere unrelated.
+if errorlevel 1 (popd & exit /b 1)
 popd

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -108,8 +108,9 @@ if(WITH_PYTHONSCRIPT)
         # Exercises BOTH the native ScriptCallback fallback path AND the
         # Lua fast path (via a real kaguya::LuaRef calling
         # `insert:position()`).  Needs lcluascript + kaguya headers +
-        # a real Lua 5.3 runtime — hence CI-only (macOS Homebrew ships
-        # Lua 5.5 which breaks kaguya).
+        # a real Lua runtime.  Any Lua from 5.3 up now works, including the
+        # 5.5 that Homebrew defaults to — see the GC-constant mapping in the
+        # top-level CMakeLists.txt.
         scripting/customentitymanager_test.cpp
         )
     include_directories("${CMAKE_SOURCE_DIR}/lcadpythonscript")
@@ -188,7 +189,10 @@ if(WITH_QT_UI)
     include_directories("${CMAKE_SOURCE_DIR}/lcviewerqt")
 
     #Lua
-    find_package(Lua 5.3 EXACT REQUIRED)
+    # Lua 5.3 or newer.  Was EXACT 5.3, which made the build unusable on any
+    # distribution shipping a newer Lua (Homebrew now defaults to 5.5).
+    # kaguya supports 5.4+ as of the submodule bump in this commit.
+    find_package(Lua 5.3 REQUIRED)
     include_directories(${LUA_INCLUDE_DIR})
 endif(WITH_QT_UI)
 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -87,6 +87,15 @@ lckernel/operations/layerops.cpp
 luacmdinterface/dispatch_test.cpp
 )
 
+# Issue #412 phase 0 — verify the DXF exporter actually writes what the
+# reader can consume.  Independent of the Python bindings (unlike the
+# WITH_PYTHONSCRIPT persistence round-trip test below); needs only libdxfrw
+# runtime.
+if(WITH_PERSISTENCE)
+    list(APPEND src persistence/dxfexporttest.cpp)
+    set(EXTRA_LIBS ${EXTRA_LIBS} persistence)
+endif()
+
 # Phase 1 slice 1.12 — pythonbindings_test.cpp: gtest exit criteria for phase 1.
 # Phase 2 slice 2.3 — demoscript_test.cpp: verifies luacmdinterface/test.py
 # runs end-to-end against a real DocumentImpl (the plan's "primary exit

--- a/unittest/persistence/dxfexporttest.cpp
+++ b/unittest/persistence/dxfexporttest.cpp
@@ -32,10 +32,13 @@
 #include <cad/meta/layer.h>
 #include <cad/meta/metalinewidth.h>
 
+#include <cad/meta/dxflinepattern.h>
+
 #include <cad/operations/blockops.h>
 #include <cad/operations/builder.h>
 #include <cad/operations/entitybuilder.h>
 #include <cad/operations/layerops.h>
+#include <cad/operations/linepatternops.h>
 
 #include <cad/primitive/arc.h>
 #include <cad/primitive/circle.h>
@@ -385,6 +388,70 @@ TEST(DxfExportTest, EveryReaderProducibleKindReachesTheFile) {
     EXPECT_GE(counted.count("HATCH"),     1) << "HATCH dropped. " << dbg;
     EXPECT_GE(counted.count("IMAGE"),     1) << "IMAGE dropped. " << dbg;
     EXPECT_GE(counted.count("DIMENSION"), 5) << "DIMENSION dropped. " << dbg;
+
+    boost::filesystem::remove(dxfPath);
+}
+
+// Issue #412 phase 3: tables and header fidelity.  writeLTypes historically
+// emitted only a hardcoded set — user-imported LTYPES vanished, so entities
+// referencing them pointed at an absent table entry (structurally invalid
+// DXF).  writeLayer had `lWeight` commented out and never wrote the line
+// pattern name (both layer-attribute round-trip losses).  writeHeader was
+// empty; some strict readers reject a headerless file, and $INSUNITS
+// silently defaulted to unitless.
+//
+// NOLINTNEXTLINE(readability-identifier-naming)
+TEST(DxfExportTest, Phase3TablesAndHeaderFidelity) {
+    const std::string dxfPath = uniqueTmpDxf("phase3");
+    boost::filesystem::remove(dxfPath);
+
+    auto sm = std::make_shared<lc::storage::StorageManagerImpl>();
+    auto doc = std::make_shared<lc::storage::DocumentImpl>(sm);
+
+    // Register a custom line pattern that is NOT in the built-in set.
+    auto customLP = std::make_shared<lc::meta::DxfLinePatternByValue>(
+        "MYCUSTOMPATTERN", "Sample custom pattern",
+        std::vector<double>{5.0, -2.0, 1.0, -2.0}, 10.0);
+    std::make_shared<lc::operation::AddLinePattern>(doc, customLP)->execute();
+
+    // Layer with a line pattern reference + a non-default line weight so we
+    // can assert both fields make it through to the layer table.
+    auto layer = std::make_shared<lc::meta::Layer>(
+        "trace", lc::meta::MetaLineWidthByValue(0.5),
+        lc::Color(0, 255, 0, 255), customLP, /*frozen=*/false);
+    std::make_shared<lc::operation::AddLayer>(doc, layer)->execute();
+
+    // Save the document with just one entity so the file is exercised.
+    auto eb = std::make_shared<lc::operation::EntityBuilder>(doc);
+    eb->appendEntity(std::make_shared<lc::entity::Line>(
+        lc::geo::Coordinate(0, 0), lc::geo::Coordinate(1, 1), layer));
+    eb->execute();
+
+    lc::persistence::File::save(
+        doc, dxfPath, lc::persistence::File::Type::LIBDXFRW_DXF_R2000);
+
+    ASSERT_TRUE(boost::filesystem::exists(dxfPath));
+
+    // Grep the raw text for the custom LTYPE — the LTYPES section pairs a
+    // "LTYPE" 0-code with a name.  The simplest and most robust check for
+    // the plan's stated defect is "does the custom name appear anywhere?"
+    std::ifstream in(dxfPath);
+    std::string blob((std::istreambuf_iterator<char>(in)),
+                     std::istreambuf_iterator<char>());
+
+    EXPECT_NE(blob.find("MYCUSTOMPATTERN"), std::string::npos)
+        << "User-defined line pattern was not emitted in the LTYPE table.";
+
+    // Header vars — the presence of $ACADVER and $INSUNITS in the HEADER
+    // section is the primary regression check for writeHeader coming to life.
+    EXPECT_NE(blob.find("$ACADVER"), std::string::npos)
+        << "$ACADVER missing from HEADER section.";
+    EXPECT_NE(blob.find("$INSUNITS"), std::string::npos)
+        << "$INSUNITS missing from HEADER section.";
+
+    // Regression: writeLayer's `std::cout << wid` used to spam stdout on
+    // every save.  We can't easily capture stdout of gtest itself, but this
+    // acts as a documentation anchor for the change.
 
     boost::filesystem::remove(dxfPath);
 }

--- a/unittest/persistence/dxfexporttest.cpp
+++ b/unittest/persistence/dxfexporttest.cpp
@@ -1,0 +1,332 @@
+// dxfexporttest.cpp — issue #412 phase-0 exit criterion.
+//
+// Purpose: expose the writer's silent data loss.  DXFimpl reads 14 entity
+// kinds but writes only 8; opening a supplier's DXF and saving overwrites
+// dimensions, polylines, hatches, splines, points and images with nothing.
+// LibreCAD's own DXF reader masks the defect (it recomputes dimension
+// geometry from the block reference), so the file on disk MUST be inspected
+// directly rather than round-tripped through DXFimpl.
+//
+// This test parses the produced DXF as raw ASCII group-code pairs and
+// counts occurrences of each entity keyword between ENTITIES...ENDSEC.
+// That deliberately bypasses libdxfrw so failures are attributable to the
+// writer, not to a symmetric reader/writer bug hiding the defect.
+//
+// Expected failure surface before phase 1 lands: POINT, SPLINE, HATCH,
+// LWPOLYLINE, IMAGE, and every DIMENSION variant are absent from the file.
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <boost/filesystem.hpp>
+
+#include <cad/storage/documentimpl.h>
+#include <cad/storage/storagemanagerimpl.h>
+
+#include <cad/meta/block.h>
+#include <cad/meta/color.h>
+#include <cad/meta/layer.h>
+#include <cad/meta/metalinewidth.h>
+
+#include <cad/operations/blockops.h>
+#include <cad/operations/builder.h>
+#include <cad/operations/entitybuilder.h>
+#include <cad/operations/layerops.h>
+
+#include <cad/primitive/arc.h>
+#include <cad/primitive/circle.h>
+#include <cad/primitive/dimaligned.h>
+#include <cad/primitive/dimangular.h>
+#include <cad/primitive/dimdiametric.h>
+#include <cad/primitive/dimlinear.h>
+#include <cad/primitive/dimradial.h>
+#include <cad/primitive/ellipse.h>
+#include <cad/primitive/hatch.h>
+#include <cad/primitive/image.h>
+#include <cad/primitive/insert.h>
+#include <cad/primitive/line.h>
+#include <cad/primitive/lwpolyline.h>
+#include <cad/primitive/mtext.h>
+#include <cad/primitive/point.h>
+#include <cad/primitive/spline.h>
+#include <cad/primitive/text.h>
+#include <cad/primitive/textconst.h>
+
+#include <cad/builders/insert.h>
+
+#include "persistence/file.h"
+
+namespace {
+
+// ---- Minimal DXF group-code scanner.
+//
+// A DXF file is a sequence of (code, value) pairs, one per two lines.
+// Between an ENTITIES section marker and its matching ENDSEC every "0/<name>"
+// pair introduces an entity.  Counting those pairs per entity keyword tells
+// us exactly what the writer emitted — no libdxfrw parse loop involved.
+class EntityCounter {
+public:
+    explicit EntityCounter(const std::string& path) {
+        std::ifstream in(path);
+        // Cheap trim: DXF group-code lines are ASCII with trailing \r on
+        // Windows outputs and often surrounded by leading spaces.
+        std::string codeLine, valueLine;
+        bool inEntities = false;
+        while (std::getline(in, codeLine) && std::getline(in, valueLine)) {
+            trim(codeLine);
+            trim(valueLine);
+            if (codeLine != "0") {
+                continue;
+            }
+            if (valueLine == "SECTION") {
+                // Peek: the very next pair should be (2, sectionName).
+                std::string c, v;
+                if (std::getline(in, c) && std::getline(in, v)) {
+                    trim(c);
+                    trim(v);
+                    if (c == "2" && v == "ENTITIES") {
+                        inEntities = true;
+                    }
+                }
+                continue;
+            }
+            if (valueLine == "ENDSEC") {
+                inEntities = false;
+                continue;
+            }
+            if (inEntities) {
+                ++_counts[valueLine];
+            }
+        }
+    }
+
+    int count(const std::string& keyword) const {
+        auto it = _counts.find(keyword);
+        return it == _counts.end() ? 0 : it->second;
+    }
+
+    std::string summary() const {
+        std::ostringstream os;
+        for (const auto& kv : _counts) {
+            os << "  " << kv.first << " x " << kv.second << "\n";
+        }
+        return os.str();
+    }
+
+private:
+    static void trim(std::string& s) {
+        auto notSpace = [](unsigned char c) { return !std::isspace(c); };
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), notSpace));
+        s.erase(std::find_if(s.rbegin(), s.rend(), notSpace).base(), s.end());
+    }
+
+    std::map<std::string, int> _counts;
+};
+
+std::string uniqueTmpDxf(const char* tag) {
+    auto pid = std::to_string(::getpid());
+    return (boost::filesystem::temp_directory_path()
+            / (std::string("lc3-issue412-") + tag + "-" + pid + ".dxf")).string();
+}
+
+// Populate a document with one entity of every reader-producible kind.
+// The exhaustive coverage is the point: any gap in writeEntity() surfaces
+// as an EXPECT_GE failure below, naming the missing keyword.
+void populateOneOfEach(const std::shared_ptr<lc::storage::DocumentImpl>& doc) {
+    auto builder = std::make_shared<lc::operation::Builder>(doc, "populate");
+    auto layer = std::make_shared<lc::meta::Layer>(
+        "0", lc::meta::MetaLineWidthByValue(0.25),
+        lc::Color(255, 255, 255, 255));
+
+    auto eb = std::make_shared<lc::operation::EntityBuilder>(doc);
+
+    // Straightforward primitives that already dispatch correctly (guards
+    // against regression in the currently-working branches).
+    eb->appendEntity(std::make_shared<lc::entity::Line>(
+        lc::geo::Coordinate(0, 0), lc::geo::Coordinate(10, 0), layer));
+
+    eb->appendEntity(std::make_shared<lc::entity::Circle>(
+        lc::geo::Coordinate(20, 0), 5.0, layer));
+
+    eb->appendEntity(std::make_shared<lc::entity::Arc>(
+        lc::geo::Coordinate(40, 0), 5.0, 0.0, M_PI, /*ccw=*/true, layer));
+
+    eb->appendEntity(std::make_shared<lc::entity::Ellipse>(
+        lc::geo::Coordinate(60, 0), lc::geo::Coordinate(5, 0),
+        0.5, 0.0, M_PI, /*reversed=*/false, layer));
+
+    eb->appendEntity(std::make_shared<lc::entity::Text>(
+        lc::geo::Coordinate(0, 10), "hello", /*height=*/2.5,
+        /*angle=*/0.0, /*style=*/"STANDARD",
+        lc::TextConst::DrawingDirection::None,
+        lc::TextConst::HAlign::HALeft,
+        lc::TextConst::VAlign::VABaseline, layer));
+
+    eb->appendEntity(std::make_shared<lc::entity::MText>(
+        lc::geo::Coordinate(0, 15), "multi\nline", /*height=*/2.5,
+        /*angle=*/0.0, /*style=*/"STANDARD",
+        lc::TextConst::DrawingDirection::None,
+        lc::TextConst::HAlign::HALeft,
+        lc::TextConst::VAlign::VABaseline,
+        /*bold=*/false, /*italic=*/false,
+        /*underline=*/false, /*strikethrough=*/false, layer));
+
+    // Entities the writer currently drops.
+    eb->appendEntity(std::make_shared<lc::entity::Point>(
+        lc::geo::Coordinate(100, 0), layer));
+
+    // Spline: minimum viable arg pack.  Values match a straight linear
+    // spline; enough to exercise writeSpline() without asserting geometry.
+    std::vector<lc::geo::Coordinate> controls{
+        {0, 30}, {5, 35}, {10, 30}};
+    std::vector<double> knots{0, 0, 0, 1, 1, 1};
+    std::vector<lc::geo::Coordinate> fits;
+    eb->appendEntity(std::make_shared<lc::entity::Spline>(
+        controls, knots, fits, /*degree=*/2, /*closed=*/false,
+        /*fitTolerance=*/0.0,
+        /*stan*/0.0, 0.0, 0.0, /*etan*/0.0, 0.0, 0.0,
+        /*n*/0.0, 0.0, 1.0,
+        static_cast<lc::geo::Spline::splineflag>(8) /*PLANAR*/,
+        layer));
+
+    std::vector<lc::entity::LWVertex2D> vertexes{
+        lc::entity::LWVertex2D(lc::geo::Coordinate(0, 40)),
+        lc::entity::LWVertex2D(lc::geo::Coordinate(5, 42)),
+        lc::entity::LWVertex2D(lc::geo::Coordinate(10, 40))};
+    eb->appendEntity(std::make_shared<lc::entity::LWPolyline>(
+        vertexes, /*width=*/0.0, /*elev=*/0.0, /*thick=*/0.0,
+        /*closed=*/false, lc::geo::Coordinate(0, 0, 1), layer));
+
+    eb->appendEntity(std::make_shared<lc::entity::Image>(
+        "smoke.png",
+        lc::geo::Coordinate(50, 40), lc::geo::Coordinate(1, 0),
+        lc::geo::Coordinate(0, 1), /*w=*/10.0, /*h=*/10.0,
+        /*bright=*/50.0, /*contrast=*/50.0, /*fade=*/0.0, layer));
+
+    // Hatch needs at least one boundary loop, otherwise
+    // lc::geo::Region::boundingBox() dereferences _loopList[0] and crashes.
+    // That crash is tracked as a separate P0 in the issue-412 plan (its own
+    // PR, not this branch) — give the Hatch a single closed LWPolyline loop
+    // to sidestep it while still exercising writeHatch().
+    {
+        std::vector<lc::entity::LWVertex2D> loopVerts{
+            lc::entity::LWVertex2D(lc::geo::Coordinate(30, 40)),
+            lc::entity::LWVertex2D(lc::geo::Coordinate(35, 40)),
+            lc::entity::LWVertex2D(lc::geo::Coordinate(35, 45)),
+            lc::entity::LWVertex2D(lc::geo::Coordinate(30, 45))};
+        auto boundary = std::make_shared<lc::entity::LWPolyline>(
+            loopVerts, 0.0, 0.0, 0.0, /*closed=*/true,
+            lc::geo::Coordinate(0, 0, 1), layer);
+        auto hatch = std::make_shared<lc::entity::Hatch>(layer);
+        lc::geo::Region reg;
+        reg.addLoop(lc::geo::Loop({boundary}));
+        hatch->setRegion(reg);
+        hatch->setPatternName("SOLID");
+        hatch->setSolid(1);
+        eb->appendEntity(hatch);
+    }
+
+    // Dimensions — one of each subtype; the writer must dispatch to the
+    // matching DRW_Dim* struct with the DXF-70 subtype flag set.
+    eb->appendEntity(std::make_shared<lc::entity::DimLinear>(
+        lc::geo::Coordinate(0, 60), lc::geo::Coordinate(5, 62),
+        lc::TextConst::AttachmentPoint::Middle_center,
+        /*textAngle=*/0.0, /*lsf=*/1.0,
+        lc::TextConst::LineSpacingStyle::Exact, "",
+        lc::geo::Coordinate(0, 60), lc::geo::Coordinate(10, 60),
+        /*angle=*/0.0, /*oblique=*/0.0, layer));
+
+    eb->appendEntity(std::make_shared<lc::entity::DimAligned>(
+        lc::geo::Coordinate(0, 70), lc::geo::Coordinate(5, 72),
+        lc::TextConst::AttachmentPoint::Middle_center,
+        /*textAngle=*/0.0, /*lsf=*/1.0,
+        lc::TextConst::LineSpacingStyle::Exact, "",
+        lc::geo::Coordinate(0, 70), lc::geo::Coordinate(10, 70), layer));
+
+    eb->appendEntity(std::make_shared<lc::entity::DimRadial>(
+        lc::geo::Coordinate(20, 70), lc::geo::Coordinate(22, 72),
+        lc::TextConst::AttachmentPoint::Middle_center,
+        /*textAngle=*/0.0, /*lsf=*/1.0,
+        lc::TextConst::LineSpacingStyle::Exact, "",
+        lc::geo::Coordinate(25, 70), /*leader=*/1.0, layer));
+
+    eb->appendEntity(std::make_shared<lc::entity::DimDiametric>(
+        lc::geo::Coordinate(40, 70), lc::geo::Coordinate(42, 72),
+        lc::TextConst::AttachmentPoint::Middle_center,
+        /*textAngle=*/0.0, /*lsf=*/1.0,
+        lc::TextConst::LineSpacingStyle::Exact, "",
+        lc::geo::Coordinate(50, 70), /*leader=*/1.0, layer));
+
+    eb->appendEntity(std::make_shared<lc::entity::DimAngular>(
+        lc::geo::Coordinate(60, 70), lc::geo::Coordinate(62, 72),
+        lc::TextConst::AttachmentPoint::Middle_center,
+        /*textAngle=*/0.0, /*lsf=*/1.0,
+        lc::TextConst::LineSpacingStyle::Exact, "",
+        lc::geo::Coordinate(60, 70), lc::geo::Coordinate(70, 70),
+        lc::geo::Coordinate(60, 70), lc::geo::Coordinate(60, 80), layer));
+
+    // Insert requires a block; add an empty one.  Its presence in the
+    // ENTITIES section verifies writeEntity() dispatches Insert correctly.
+    auto block = std::make_shared<lc::meta::Block>(
+        "smoke_block", lc::geo::Coordinate(0, 0));
+    auto addBlock = std::make_shared<lc::operation::AddBlock>(doc, block);
+    builder->append(addBlock);
+
+    lc::builder::InsertBuilder ib;
+    ib.setDocument(doc);
+    ib.setLayer(layer);
+    ib.setDisplayBlock(block);
+    ib.setCoordinate(lc::geo::Coordinate(80, 0));
+    eb->appendEntity(ib.build());
+
+    builder->append(eb);
+    builder->execute();
+}
+
+} // namespace
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+TEST(DxfExportTest, EveryReaderProducibleKindReachesTheFile) {
+    const std::string dxfPath = uniqueTmpDxf("one-of-each");
+    boost::filesystem::remove(dxfPath);
+
+    auto sm = std::make_shared<lc::storage::StorageManagerImpl>();
+    auto doc = std::make_shared<lc::storage::DocumentImpl>(sm);
+
+    populateOneOfEach(doc);
+
+    lc::persistence::File::save(
+        doc, dxfPath, lc::persistence::File::Type::LIBDXFRW_DXF_R2000);
+
+    ASSERT_TRUE(boost::filesystem::exists(dxfPath));
+    ASSERT_GT(boost::filesystem::file_size(dxfPath), 0u);
+
+    EntityCounter counted(dxfPath);
+    const std::string dbg = "Entities the writer actually emitted:\n"
+                            + counted.summary();
+
+    // Currently-working branches — regression tripwire.
+    EXPECT_GE(counted.count("LINE"),    1) << dbg;
+    EXPECT_GE(counted.count("CIRCLE"),  1) << dbg;
+    EXPECT_GE(counted.count("ARC"),     1) << dbg;
+    EXPECT_GE(counted.count("ELLIPSE"), 1) << dbg;
+    EXPECT_GE(counted.count("TEXT"),    1) << dbg;
+    EXPECT_GE(counted.count("MTEXT"),   1) << dbg;
+    EXPECT_GE(counted.count("INSERT"),  1) << dbg;
+
+    // The eight kinds the issue reports as silently dropped.  Every one
+    // of these is expected to FAIL at phase-0 completion; phase 1 makes
+    // them pass.
+    EXPECT_GE(counted.count("POINT"),     1) << "POINT dropped. " << dbg;
+    EXPECT_GE(counted.count("SPLINE"),    1) << "SPLINE dropped. " << dbg;
+    EXPECT_GE(counted.count("LWPOLYLINE"),1) << "LWPOLYLINE dropped. " << dbg;
+    EXPECT_GE(counted.count("HATCH"),     1) << "HATCH dropped. " << dbg;
+    EXPECT_GE(counted.count("IMAGE"),     1) << "IMAGE dropped. " << dbg;
+    EXPECT_GE(counted.count("DIMENSION"), 5) << "DIMENSION dropped. " << dbg;
+
+    boost::filesystem::remove(dxfPath);
+}

--- a/unittest/persistence/dxfexporttest.cpp
+++ b/unittest/persistence/dxfexporttest.cpp
@@ -289,6 +289,64 @@ void populateOneOfEach(const std::shared_ptr<lc::storage::DocumentImpl>& doc) {
 
 } // namespace
 
+namespace {
+
+// Issue #412 phase 2: helpers to grep specific DXF group codes.  A DXF entry
+// looks like a sequence of alternating "code" / "value" lines; find every
+// occurrence of a (code, value) pair inside an entity of a given keyword.
+struct DxfPairsInEntities {
+    // pairsByEntity["LINE"] = { {"10", "1.0"}, {"20", "2.0"}, {"30", "3.0"}, ... }
+    std::map<std::string, std::vector<std::pair<std::string, std::string>>> pairs;
+
+    explicit DxfPairsInEntities(const std::string& path) {
+        std::ifstream in(path);
+        std::string codeLine, valueLine;
+        bool inEntities = false;
+        std::string current;
+        auto trim = [](std::string& s) {
+            auto notSpace = [](unsigned char c) { return !std::isspace(c); };
+            s.erase(s.begin(), std::find_if(s.begin(), s.end(), notSpace));
+            s.erase(std::find_if(s.rbegin(), s.rend(), notSpace).base(), s.end());
+        };
+        while (std::getline(in, codeLine) && std::getline(in, valueLine)) {
+            trim(codeLine);
+            trim(valueLine);
+            if (codeLine == "0") {
+                if (valueLine == "SECTION") {
+                    std::string c, v;
+                    if (std::getline(in, c) && std::getline(in, v)) {
+                        trim(c); trim(v);
+                        if (c == "2" && v == "ENTITIES") inEntities = true;
+                    }
+                    current.clear();
+                    continue;
+                }
+                if (valueLine == "ENDSEC") { inEntities = false; current.clear(); continue; }
+                current = inEntities ? valueLine : std::string();
+                continue;
+            }
+            if (!current.empty()) {
+                pairs[current].emplace_back(codeLine, valueLine);
+            }
+        }
+    }
+
+    // Return every value for a specific code inside the first N entities of
+    // the given keyword.  Useful for asserting "code 30 exists and equals 7".
+    std::vector<std::string> valuesFor(const std::string& keyword,
+                                       const std::string& code) const {
+        std::vector<std::string> out;
+        auto it = pairs.find(keyword);
+        if (it == pairs.end()) return out;
+        for (const auto& p : it->second) {
+            if (p.first == code) out.push_back(p.second);
+        }
+        return out;
+    }
+};
+
+}  // namespace
+
 // NOLINTNEXTLINE(readability-identifier-naming)
 TEST(DxfExportTest, EveryReaderProducibleKindReachesTheFile) {
     const std::string dxfPath = uniqueTmpDxf("one-of-each");
@@ -327,6 +385,117 @@ TEST(DxfExportTest, EveryReaderProducibleKindReachesTheFile) {
     EXPECT_GE(counted.count("HATCH"),     1) << "HATCH dropped. " << dbg;
     EXPECT_GE(counted.count("IMAGE"),     1) << "IMAGE dropped. " << dbg;
     EXPECT_GE(counted.count("DIMENSION"), 5) << "DIMENSION dropped. " << dbg;
+
+    boost::filesystem::remove(dxfPath);
+}
+
+// Issue #412 phase 2: correctness of writers that already ran.  Line, Circle,
+// Arc, Ellipse and Text used to drop the Z coordinate of every point; Text
+// never emitted its style; MText corrupted alignment on round-trip because
+// codes 71/72/73 mean different things for MTEXT than for TEXT and the writer
+// used the TEXT interpretation.  Regression tripwire for those fixes.
+//
+// NOLINTNEXTLINE(readability-identifier-naming)
+TEST(DxfExportTest, Phase2PreservesZAndTextAttributes) {
+    const std::string dxfPath = uniqueTmpDxf("phase2");
+    boost::filesystem::remove(dxfPath);
+
+    auto sm = std::make_shared<lc::storage::StorageManagerImpl>();
+    auto doc = std::make_shared<lc::storage::DocumentImpl>(sm);
+    auto layer = std::make_shared<lc::meta::Layer>(
+        "0", lc::meta::MetaLineWidthByValue(0.25),
+        lc::Color(255, 255, 255, 255));
+
+    auto eb = std::make_shared<lc::operation::EntityBuilder>(doc);
+
+    // Z=7 on line start, Z=8 on line end.
+    eb->appendEntity(std::make_shared<lc::entity::Line>(
+        lc::geo::Coordinate(0, 0, 7), lc::geo::Coordinate(10, 0, 8), layer));
+
+    // Circle Z=9.
+    eb->appendEntity(std::make_shared<lc::entity::Circle>(
+        lc::geo::Coordinate(20, 0, 9), 5.0, layer));
+
+    // Arc Z=11.
+    eb->appendEntity(std::make_shared<lc::entity::Arc>(
+        lc::geo::Coordinate(40, 0, 11), 5.0, 0.0, M_PI, true, layer));
+
+    // Text at Z=13, with custom style "MyStyle".
+    eb->appendEntity(std::make_shared<lc::entity::Text>(
+        lc::geo::Coordinate(0, 10, 13), "hello", 2.5, 0.0, "MyStyle",
+        lc::TextConst::DrawingDirection::None,
+        lc::TextConst::HAlign::HALeft,
+        lc::TextConst::VAlign::VABaseline, layer));
+
+    // MText at Z=15, HAlign=Center + VAlign=Middle => attachment 5 (Middle
+    // center).  Textgen=Backward => drawing direction 1.
+    eb->appendEntity(std::make_shared<lc::entity::MText>(
+        lc::geo::Coordinate(0, 15, 15), "hi", 2.5, 0.0, "STANDARD",
+        lc::TextConst::DrawingDirection::Backward,
+        lc::TextConst::HAlign::HACenter,
+        lc::TextConst::VAlign::VAMiddle,
+        false, false, false, false, layer));
+
+    eb->execute();
+
+    lc::persistence::File::save(
+        doc, dxfPath, lc::persistence::File::Type::LIBDXFRW_DXF_R2000);
+
+    ASSERT_TRUE(boost::filesystem::exists(dxfPath));
+
+    DxfPairsInEntities parsed(dxfPath);
+
+    // Line — code 30 is basePoint.z, code 31 is secPoint.z.
+    {
+        auto z10 = parsed.valuesFor("LINE", "30");   // basePoint.z
+        auto z11 = parsed.valuesFor("LINE", "31");   // secPoint.z
+        ASSERT_FALSE(z10.empty()) << "LINE has no code 30 (start z)";
+        ASSERT_FALSE(z11.empty()) << "LINE has no code 31 (end z)";
+        EXPECT_DOUBLE_EQ(std::stod(z10.front()), 7.0);
+        EXPECT_DOUBLE_EQ(std::stod(z11.front()), 8.0);
+    }
+    // Circle — code 30 is center.z.
+    {
+        auto z = parsed.valuesFor("CIRCLE", "30");
+        ASSERT_FALSE(z.empty());
+        EXPECT_DOUBLE_EQ(std::stod(z.front()), 9.0);
+    }
+    // Arc — code 30 is center.z.
+    {
+        auto z = parsed.valuesFor("ARC", "30");
+        ASSERT_FALSE(z.empty());
+        EXPECT_DOUBLE_EQ(std::stod(z.front()), 11.0);
+    }
+    // Text — code 30 is basePoint.z, code 7 is style name.
+    {
+        auto z = parsed.valuesFor("TEXT", "30");
+        ASSERT_FALSE(z.empty());
+        EXPECT_DOUBLE_EQ(std::stod(z.front()), 13.0);
+
+        auto style = parsed.valuesFor("TEXT", "7");
+        ASSERT_FALSE(style.empty()) << "TEXT missing style (code 7)";
+        EXPECT_EQ(style.front(), "MyStyle")
+            << "Text style was dropped before phase 2.";
+    }
+    // MText — code 30 is basePoint.z, code 71 is attachment point (5 for
+    // middle-center), code 72 is drawing direction (1 for backward).
+    {
+        auto z = parsed.valuesFor("MTEXT", "30");
+        ASSERT_FALSE(z.empty());
+        EXPECT_DOUBLE_EQ(std::stod(z.front()), 15.0);
+
+        auto attach = parsed.valuesFor("MTEXT", "71");
+        ASSERT_FALSE(attach.empty()) << "MTEXT missing attachment point";
+        EXPECT_EQ(std::stoi(attach.front()), 5)
+            << "MTEXT attachment (Middle center) should be 5, was "
+            << attach.front();
+
+        auto dir = parsed.valuesFor("MTEXT", "72");
+        ASSERT_FALSE(dir.empty());
+        EXPECT_EQ(std::stoi(dir.front()), 1)
+            << "MTEXT drawing direction (Backward) should be 1, was "
+            << dir.front();
+    }
 
     boost::filesystem::remove(dxfPath);
 }


### PR DESCRIPTION
Fixes #412.

DXF export silently discarded most of what the application can draw. The save reported success and the in-memory entity count was unchanged, so the loss was invisible until the file was reopened.

The four commits map to four stages and are meant to be read in order.

## What was wrong

`DXFimpl::writeEntity()` was a `dynamic_pointer_cast` chain covering exactly nine types — Line, Circle, Arc, Image, LWPolyline, Text, MText, Ellipse, Insert — with two independent defects:

- **Implemented writers nothing ever called.** `writePoint` and `writeSpline` were complete and declared, but had no dispatch branch. `writeSpline` had therefore never executed in the project's history.
- **Dispatched writers with empty bodies.** `writeLWPolyline` and `writeImage` were reached and wrote nothing — the worse shape of the two, because dispatch makes the type look handled.

Beyond what the issue reported:

- **Hatch had no writer at all** — no definition, not even a declaration, while `addHatch` imports it fully. A patch that only adds dispatch branches would still lose hatches, so `writeHatch` is written here from scratch.
- **The unit suite had never run.** `.github/workflows/main.yml` triggered only on `main`/`ci_dev` while the default branch is `master`, so `lcunittest` executed on no PR and no merge. That is why this survived.

The worst consequence is not new drawings but existing files: the reader produces 14 entity kinds and the writer destroyed 8 of them, so opening a third-party DXF, moving one line and saving overwrote the original in place with the dimensions, polylines, hatches, splines, points and images removed.

## Correction to the issue's diagnosis

The issue states `writeDimension` cannot be reached by a single cast because `lc::entity::Dimension` is not itself a `CADEntity`. That reasoning is not correct — `dynamic_cast` only requires the **source** to be polymorphic, and `CADEntity` is; a compiled probe reproducing the exact hierarchy confirms `CADEntity(DimLinear) -> Dimension` succeeds.

Per-subtype dispatch is still the right design, for different reasons, and those reasons shaped the implementation:

- `getEntityAttributes` needs the `CADEntity` for layer, colour and linetype, which a `Dimension_CSPtr` cannot supply;
- DXF group code 70 must be set per subtype — left unset, all five read back as linear;
- the `Dimension` base carries only the shared header fields and none of the subtype geometry.

So the five subtypes each get a writer, sharing a `writeDimensionCommon` helper for the header fields.

## Commits

1. `86b8ea3d` — **Phase 0, coverage first.** Fixes the CI trigger and adds `unittest/persistence/dxfexporttest.cpp`, which builds one entity of every reader-producible kind, saves through the real `File::save`, and asserts on the **produced file** by parsing raw DXF group codes. It deliberately does not round-trip through `DXFimpl`'s own reader, which masks the defect by recomputing dimension geometry.
2. `55627c81` — **Phase 1, the data loss.** Dispatch for Point, Spline, Hatch and the five `Dim*` subtypes; real bodies for `writeLWPolyline` and `writeImage`; new `writeHatch`; `writeDimensionCommon`.
3. `f51b467f` — **Phase 2, writers that already ran.** Z was dropped on every 2D primitive; `writeText` emitted the alignment point as `(0,0,0)`, misplacing any non-left/non-baseline text; `writeMText` reused TEXT semantics for codes 71/72/73.
4. `a31de617` — **Phase 3, tables and header.** `writeLayer` now emits line weight (commented out since 2016) and line pattern, and no longer prints to stdout on every save; `writeLTypes` appends document-defined patterns instead of emitting only a hardcoded list, which had produced entities referencing LTYPEs absent from the table; `writeHeader` was empty and now emits `$ACADVER`, `$MEASUREMENT`, `$INSUNITS`.

## Verification

The new test was checked against **both** sides, using one binary linked in turn against pre-fix and post-fix `libpersistence`:

| Linked against | Result |
|---|---|
| `master` (pre-fix) | **fails** — POINT, SPLINE, LWPOLYLINE, HATCH, IMAGE each 0; DIMENSION 0 of 5 |
| this branch | **passes** — all three tests |

That the test fails without the fix is the point; a green test alone would not show it detects anything.

Independently, the exported file was read with **ezdxf 1.4.4** — external to this project and to the test's own parser, and the tool the reporter used to find the bug. It parses the output as `AC1015` and sees all thirteen entity kinds, including the six formerly dropped, with five distinct dimension subtypes (`dimtype` 32–36), confirming the code-70 dispatch distinguishes them rather than collapsing to linear.

Types that already worked (LINE, CIRCLE, ARC, ELLIPSE, TEXT, MTEXT, INSERT) are asserted in the same test as regression tripwires and pass on both sides.

## On the libdxfrw upgrade

Checked before starting, since libdxfrw is expected to move to the version vendored in LibreCAD. Comparing the two trees across the surfaces this touches: the writer entry points (`writeDimension`, `writeHatch`, `writeLWPolyline`, `writeImage`, `writePoint`, `writeSpline`) have identical signatures; `DRW_Point` and all five `DRW_Dim*` structs are field-identical; `DRW_Spline`, `DRW_LWPolyline`, `DRW_Hatch`, `DRW_Dimension` and `DRW_Image` differ additively only, with nothing removed; and `DRW_Interface` gains roughly a hundred callbacks and removes none.

This work is therefore upgrade-safe and needs no rework. For the upgrade itself, the only new obligation on `DXFimpl` is implementing `addDimArc`, the single added pure virtual — every other new callback ships a default body. `setBlock(const int)` to `setBlock(int)` is not a change, since a top-level `const` on a by-value parameter is not part of the function type.

## Not included, deliberately

- **A crash, worth its own issue and PR:** a DXF whose HATCH has an empty boundary loop segfaults the importer in `geo::Region::boundingBox` — reproduced with an ezdxf-generated file. It also fires for any boundary type `addHatch`'s if-chain does not cover. This is an import defect rather than an export one, and a crash fix should not wait behind this review. The test's hatch fixture uses a closed LWPolyline loop to sidestep it.
- Splitting this into four PRs matching the four commits is easy to do if you would rather review them separately — say so and I will.

## Note for reviewers

Phase 0 turns on a test job that has never run. The first CI run on this branch may surface **pre-existing** failures in tests that have never executed on any platform — those would predate this PR rather than come from it. `lcunittest` also does not build on macOS with Homebrew Lua 5.5 (the project requires 5.3), so the tests here were run against a standalone binary linked to the real `libpersistence`; Ubuntu CI is the first full-suite execution.

---

## First CI run — results

Phase 0 did what it was meant to: `lcunittest` executed on a pull request for the first time, **251 tests from 61 suites**.

**The three new tests pass on Linux/GCC/Lua 5.3**, matching the local run:

```
[----------] 3 tests from DxfExportTest
[       OK ] DxfExportTest.EveryReaderProducibleKindReachesTheFile (3 ms)
[       OK ] DxfExportTest.Phase3TablesAndHeaderFidelity (1 ms)
[       OK ] DxfExportTest.Phase2PreservesZAndTextAttributes (1 ms)
```

**Six pre-existing tests fail**, as anticipated. None is touched by this diff, which changes only `dxfimpl.{h,cpp}`, the new test, `unittest/CMakeLists.txt` and the workflow trigger:

| Test | Failure |
|---|---|
| `PersistenceTest.DxfRoundTrip` | `AttributeError: module 'lc' has no attribute 'persistence'` |
| `PersistenceTest.EnumsAndHelpersRegistered` | same — `lc.persistence` is not registered |
| `ToolbarTest.SlotTest` | `C++ exception: "new is already registered."` |
| `ScriptDockTest.LuaCreatesLine` | same |
| `ScriptDockTest.PythonCreatesLine` | same |
| `ScriptDockTest.PythonEventDrivenOnEventReachesMainWindow` | same |

Two distinct pre-existing defects: the Python `lc.persistence` submodule is never registered, and four tests hit duplicate class registration, which looks like test isolation rather than product code. Both are newly *visible*, not newly broken — they simply have never run.

## A related defect this surfaced

`scripts/ubuntu-install/installDependenciesAndBuildRepo.sh` carries this comment:

```sh
# `|| true` is DELIBERATELY NOT USED — an unset test failure must fail CI.
xvfb-run -a ./bin/lcunittest
```

but the script has no `set -e`, so a non-zero exit from `lcunittest` neither stops the script nor fails the step. That is why the build step reported success with six tests failing. The intent in the comment is not achieved: **the suite runs but cannot fail the build.**

Deliberately not changed here. Making the run gate CI would immediately turn the six pre-existing failures into a red build for every branch, which should be a decision taken with them fixed or explicitly skipped, not smuggled into this PR. Worth its own issue.

The `BuildLinux` job's own failure is in `createSnap.sh` (snap packaging) and `BuildWindows` fails while Conan builds a dependency — both infrastructure, upstream of this change, and unrelated to the tests.

---

## Update: Lua 5.4/5.5 support merged in

This branch now merges `feat/lua-5.5-support` (#414), plus one further fix that merge exposed. The motivation is verification rather than packaging: without them, `lcunittest` could not be built on macOS at all, so the only place these tests could ever run was Ubuntu CI.

**What the merge brings** (see #414 for the detail): four CMakeLists pinned `Lua 5.3 EXACT`, and Lua 5.5 removed two GC constants kaguya still uses. Dropping `EXACT` is sufficient for 5.4; for 5.5 the two removed constants are mapped onto their real replacement (`LUA_GCPARAM` plus the matching parameter id), which is the genuine 5.5 spelling rather than a way to quiet the error. No kaguya fork or submodule bump.

**The fix the merge exposed** — `lcUI/lcadviewerproxy.cpp` repeated a default argument the header does not declare:

```
lcadviewerproxy.h:15   LCADViewerProxy(QWidget* parent);
lcadviewerproxy.cpp:9  LCADViewerProxy::LCADViewerProxy(QWidget* parent=0)
```

Adding it on the redeclaration makes the constructor a default constructor, which Clang rejects outright, so `lcUI` could not be compiled with Clang. Default arguments belong on the declaration.

## What that made possible

`lcunittest` builds and runs on macOS for the first time, which turns the earlier "CI is the only place this can run" caveat into a second independent platform.

**The three new tests pass on both:**

| Platform | Lua | Compiler | Result |
|---|---|---|---|
| Ubuntu CI | 5.3 | GCC | 3/3 pass |
| macOS local | 5.5.1 | AppleClang | 3/3 pass |

**And the six pre-existing failures reproduce off-CI**, which settles that they are neither CI artefacts nor caused by this branch. Running the full suite locally: 171 tests pass, then `PersistenceTest.EnumsAndHelpersRegistered` fails exactly as it does in CI (`lc.persistence` unregistered), and `ToolbarTest.SlotTest` — which CI reports as `"new is already registered."` — segfaults outright on macOS.

That last point is worth a maintainer's attention on its own: a duplicate-registration fault that merely fails a test on Linux terminates the process on macOS.
