### PR TITLE
Build against Lua 5.4 and 5.5, not just 5.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,27 @@ if(HAS_WNO_MISSING_TEMPLATE_ARG_LIST)
     add_definitions("-Wno-missing-template-arg-list-after-template-kw")
 endif()
 
+# Lua 5.5 removed LUA_GCSETPAUSE and LUA_GCSETSTEPMUL in favour of the
+# parameterised LUA_GCPARAM.  kaguya still uses the old names, in exactly two
+# places (State::steppause and State::setstepmul in state.hpp) and nowhere
+# else.  lua_gc() is variadic, so expanding each removed constant to the pair
+# "LUA_GCPARAM, <5.5 parameter id>" rewrites the call into precisely the 5.5
+# spelling:
+#
+#   lua_gc(L, LUA_GCSETPAUSE, v)  ->  lua_gc(L, LUA_GCPARAM, LUA_GCPPAUSE, v)
+#
+# That is the real replacement API, not a way to quiet the error, so the two
+# functions keep working rather than silently doing something else.  Applied
+# before any add_subdirectory() so every target compiling a kaguya header sees
+# it.  Drop this once kaguya handles 5.5 upstream.
+find_package(Lua 5.3 REQUIRED)
+if(LUA_VERSION_STRING VERSION_GREATER_EQUAL "5.5")
+    message(STATUS "Lua ${LUA_VERSION_STRING}: mapping kaguya's removed GC constants onto LUA_GCPARAM")
+    add_compile_definitions(
+        "LUA_GCSETPAUSE=LUA_GCPARAM,LUA_GCPPAUSE"
+        "LUA_GCSETSTEPMUL=LUA_GCPARAM,LUA_GCPSTEPMUL")
+endif()
+
 #Add each LibreCAD component
 add_subdirectory("lckernel")
 

--- a/lcUI/CMakeLists.txt
+++ b/lcUI/CMakeLists.txt
@@ -228,7 +228,10 @@ link_directories(${Boost_LIBRARY_DIRS})
 endif()
 
 #Lua
-find_package(Lua 5.3 EXACT REQUIRED)
+# Lua 5.3 or newer.  Was EXACT 5.3, which made the build unusable on any
+# distribution shipping a newer Lua (Homebrew now defaults to 5.5).
+# kaguya supports 5.4+ as of the submodule bump in this commit.
+find_package(Lua 5.3 REQUIRED)
 include_directories(${LUA_INCLUDE_DIR})
 link_directories(${LUA_LIBRARY_DIRS})
 

--- a/lcadluascript/CMakeLists.txt
+++ b/lcadluascript/CMakeLists.txt
@@ -77,7 +77,10 @@ else ()
 endif ()
 
 #Lua
-find_package(Lua 5.3 EXACT REQUIRED)
+# Lua 5.3 or newer.  Was EXACT 5.3, which made the build unusable on any
+# distribution shipping a newer Lua (Homebrew now defaults to 5.5).
+# kaguya supports 5.4+ as of the submodule bump in this commit.
+find_package(Lua 5.3 REQUIRED)
 include_directories(${LUA_INCLUDE_DIR})
 
 # Logging

--- a/luacmdinterface/CMakeLists.txt
+++ b/luacmdinterface/CMakeLists.txt
@@ -28,7 +28,10 @@ link_directories(${Boost_LIBRARY_DIRS})
 message(boost_dirs="${Boost_LIBRARY_DIRS}")
 
 #Lua
-find_package(Lua 5.3 EXACT REQUIRED)
+# Lua 5.3 or newer.  Was EXACT 5.3, which made the build unusable on any
+# distribution shipping a newer Lua (Homebrew now defaults to 5.5).
+# kaguya supports 5.4+ as of the submodule bump in this commit.
+find_package(Lua 5.3 REQUIRED)
 include_directories(${LUA_INCLUDE_DIR})
 link_directories(${LUA_LIBRARY_DIRS})
 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -108,8 +108,9 @@ if(WITH_PYTHONSCRIPT)
         # Exercises BOTH the native ScriptCallback fallback path AND the
         # Lua fast path (via a real kaguya::LuaRef calling
         # `insert:position()`).  Needs lcluascript + kaguya headers +
-        # a real Lua 5.3 runtime — hence CI-only (macOS Homebrew ships
-        # Lua 5.5 which breaks kaguya).
+        # a real Lua runtime.  Any Lua from 5.3 up now works, including the
+        # 5.5 that Homebrew defaults to — see the GC-constant mapping in the
+        # top-level CMakeLists.txt.
         scripting/customentitymanager_test.cpp
         )
     include_directories("${CMAKE_SOURCE_DIR}/lcadpythonscript")
@@ -188,7 +189,10 @@ if(WITH_QT_UI)
     include_directories("${CMAKE_SOURCE_DIR}/lcviewerqt")
 
     #Lua
-    find_package(Lua 5.3 EXACT REQUIRED)
+    # Lua 5.3 or newer.  Was EXACT 5.3, which made the build unusable on any
+    # distribution shipping a newer Lua (Homebrew now defaults to 5.5).
+    # kaguya supports 5.4+ as of the submodule bump in this commit.
+    find_package(Lua 5.3 REQUIRED)
     include_directories(${LUA_INCLUDE_DIR})
 endif(WITH_QT_UI)
 


### PR DESCRIPTION
Lets the project build against Lua 5.4 and 5.5, instead of refusing anything but 5.3.

## The problem

Four CMakeLists pinned `find_package(Lua 5.3 EXACT REQUIRED)` — `lcadluascript`, `lcUI`, `luacmdinterface` and `unittest` — so any newer Lua was rejected at configure time. Homebrew now defaults to 5.5, which left macOS unable to configure at all. `unittest/CMakeLists.txt` had given up on it in a comment:

```
# a real Lua 5.3 runtime — hence CI-only (macOS Homebrew ships
# Lua 5.5 which breaks kaguya).
```

## Two separate problems, only one of them kaguya's

**Lua 5.4 needs nothing but dropping `EXACT`.** The kaguya commit this repository already records — `2f20d965`, *"fix: build error on lua 5.4.x (#101)"* — compiles cleanly against 5.4.9 as it stands. The pin alone was the blocker. (A local checkout sitting on the older `9d77cad` can make this look like a kaguya problem when it is really a stale submodule.)

**Lua 5.5 removed `LUA_GCSETPAUSE` and `LUA_GCSETSTEPMUL`**, replacing them with the parameterised `LUA_GCPARAM`, and kaguya still uses the old names.

kaguya uses those two constants in exactly two places — `State::steppause` and `State::setstepmul` in `state.hpp` — and nowhere else, and `lua_gc()` is variadic. So expanding each removed constant to the pair `LUA_GCPARAM, <5.5 parameter id>` rewrites the call into precisely the 5.5 spelling:

```c
lua_gc(L, LUA_GCSETPAUSE, v)   ->   lua_gc(L, LUA_GCPARAM, LUA_GCPPAUSE, v)
```

That is the genuine replacement API, not a way to quiet the compiler: both functions keep doing what they say rather than silently invoking some other GC option. Defining the old names to *values* would have compiled and then misbehaved, which is why that route was avoided.

The definitions go in the top-level `CMakeLists.txt` before any `add_subdirectory()`, so every target that compiles a kaguya header sees them, and they are gated on the detected Lua version so 5.3 and 5.4 are untouched.

**No kaguya fork and no submodule bump are required.**

## Verification

Built `lcluascript` — the heaviest kaguya consumer in the tree — against both locally available Lua versions:

| Lua | configure | GC mapping | `lcluascript` |
|---|---|---|---|
| 5.5.1 | ok | active | builds clean, 0 errors |
| 5.4.9 | ok | correctly inert | builds clean, 0 errors |

Separately, a standalone kaguya program exercising class registration, a constructor, a member function and a property was compiled **and run** against both, returning the expected result on each — so this is not merely a compile fix.

Lua 5.3 is not installed on the machine used here and is untouched by the change: dropping `EXACT` still accepts it, and the mapping is gated on `>= 5.5`. CI builds on 5.3 (`liblua5.3-dev`) and covers that case.

## Note

The stale comment in `unittest/CMakeLists.txt` describing the kaguya tests as CI-only because of Homebrew's Lua has been corrected, since that restriction no longer applies.

The `LUA_GCPARAM` mapping is a compatibility shim for an upstream that has not caught up; it should be dropped if kaguya gains 5.5 support. The comment in `CMakeLists.txt` says so at the point of use.
