### PR TITLE
Fix compiler warnings: binary_function, Qt/GLEW include order, unrecognized -Wno flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,8 +207,19 @@ endif(WITH_CAIRO)
 # diagnostic globally, before any add_subdirectory(), if the compiler
 # supports the flag.
 include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-Wno-missing-template-arg-list-after-template-kw" HAS_WNO_MISSING_TEMPLATE_ARG_LIST)
-if(HAS_WNO_MISSING_TEMPLATE_ARG_LIST)
+# Probe the POSITIVE spelling even though the negative one is what gets added.
+# GCC accepts any unrecognised -Wno-* silently, so probing "-Wno-..." succeeds
+# there and the flag gets added to a compiler that does not know it -- GCC then
+# reports, on every file that emits any other diagnostic:
+#
+#   cc1plus: note: unrecognized command-line option
+#   '-Wno-missing-template-arg-list-after-template-kw' may have been intended
+#   to silence earlier diagnostics
+#
+# GCC does reject the positive spelling outright, so probing that tells the two
+# compilers apart and the flag reaches Clang only.
+check_cxx_compiler_flag("-Wmissing-template-arg-list-after-template-kw" HAS_MISSING_TEMPLATE_ARG_LIST_WARNING)
+if(HAS_MISSING_TEMPLATE_ARG_LIST_WARNING)
     add_definitions("-Wno-missing-template-arg-list-after-template-kw")
 endif()
 

--- a/lcUI/CMakeLists.txt
+++ b/lcUI/CMakeLists.txt
@@ -31,6 +31,7 @@ cadmdichild.h
 const.h
 luainterface.h
 lcadviewer.h
+glewsupport.h
 lcadviewerproxy.h
 lcadmodelviewerimpl.h
 lcadpaperviewerimpl.h
@@ -101,6 +102,7 @@ cadmdichild.cpp
 main.cpp
 luainterface.cpp
 lcadviewer.cpp
+glewsupport.cpp
 lcadviewerproxy.cpp
 lcadmodelviewerimpl.cpp
 lcadpaperviewerimpl.cpp

--- a/lcUI/dialogs/aboutdialog.cpp
+++ b/lcUI/dialogs/aboutdialog.cpp
@@ -56,7 +56,6 @@ QString getOsName(outputConfig& oc)
         return oc.lineFormat.arg("OS").arg("Linux");
     }
     QString out;
-    QString machine();
     out +=
         oc.lineFormat.arg("system name").arg(buffer.sysname) +
         oc.lineFormat.arg("release").arg(buffer.release) +

--- a/lcUI/dialogs/textdialog.cpp
+++ b/lcUI/dialogs/textdialog.cpp
@@ -14,8 +14,8 @@ using namespace lc::ui::dialog;
 
 TextDialog::TextDialog(lc::ui::MainWindow* mainWindowIn, QWidget* parent)
     : QDialog(parent),
-      _mainWindow(mainWindowIn),
-      ui(new Ui::TextDialog)
+    ui(new Ui::TextDialog),
+    _mainWindow(mainWindowIn)
 {
     ui->setupUi(this);
 

--- a/lcUI/glewsupport.cpp
+++ b/lcUI/glewsupport.cpp
@@ -1,0 +1,29 @@
+#include "glewsupport.h"
+
+// Deliberately the only Qt-free translation unit that touches GLEW.  Do not add
+// a Qt OpenGL include here: Qt's qopengl.h warns and undefines GLEW's macros
+// when glew.h precedes it, and glew.h refuses to compile when gl.h precedes it.
+#include <GL/glew.h>
+
+namespace lc {
+namespace ui {
+
+bool initialiseGlew(std::string& error) {
+    const GLenum err = glewInit();
+
+    if (err != GLEW_OK) {
+        error = "GLEW Error: ";
+        error += reinterpret_cast<const char*>(glewGetErrorString(err));
+        return false;
+    }
+
+    if (!GLEW_VERSION_2_1) {
+        error = "OpenGL version 2.1 is not available";
+        return false;
+    }
+
+    return true;
+}
+
+}
+}

--- a/lcUI/glewsupport.h
+++ b/lcUI/glewsupport.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+namespace lc {
+namespace ui {
+
+/**
+ * Initialise GLEW and verify the OpenGL version the painters need.
+ *
+ * Returns true on success.  On failure `error` carries a message ready to log.
+ *
+ * This lives behind a plain function on purpose.  Qt's qopengl.h warns, and
+ * undefines GLEW's macros, whenever glew.h has been included before it; GLEW in
+ * turn refuses to compile when gl.h has been included before glew.h, which Qt's
+ * OpenGL headers do. No include order satisfies both inside a single
+ * translation unit, so glewsupport.cpp includes glew.h and no Qt OpenGL header
+ * at all, and callers see only this declaration.
+ */
+bool initialiseGlew(std::string& error);
+
+}
+}

--- a/lcUI/lcadviewer.cpp
+++ b/lcUI/lcadviewer.cpp
@@ -1,4 +1,5 @@
 #include "lcadviewer.h"
+#include "glewsupport.h"
 #include <QtGui>
 #include <QVBoxLayout>
 #include <iostream>
@@ -123,14 +124,10 @@ void LCADViewer::initializeGL()
 
     if (CC != 0)
     {
-        GLenum err = glewInit();
+        std::string glewError;
 
-        if (err != GLEW_OK) {
-            LOG_ERROR << "GLEW Error: " << glewGetErrorString(err) << std::endl;
-            exit(1);
-        }
-        if (!GLEW_VERSION_2_1) {
-            LOG_ERROR << "OpenGL version 2.1 is not available" << std::endl;
+        if (!initialiseGlew(glewError)) {
+            LOG_ERROR << glewError << std::endl;
             exit(1);
         }
 

--- a/lcUI/lcadviewer.cpp
+++ b/lcUI/lcadviewer.cpp
@@ -61,6 +61,9 @@ void LCADViewer::messageLogged(const QOpenGLDebugMessage &msg)
         CASE(ApplicationSource);
         CASE(OtherSource);
         CASE(InvalidSource);
+        // AnySource/AnyType/AnySeverity are Qt's filter sentinels and
+        // Invalid* cannot arrive on a real message; nothing to name.
+        default: break;
     }
 #undef CASE
 
@@ -79,6 +82,9 @@ void LCADViewer::messageLogged(const QOpenGLDebugMessage &msg)
         CASE(MarkerType);
         CASE(GroupPushType);
         CASE(GroupPopType);
+        // AnySource/AnyType/AnySeverity are Qt's filter sentinels and
+        // Invalid* cannot arrive on a real message; nothing to name.
+        default: break;
     }
 #undef CASE
 
@@ -97,6 +103,11 @@ void LCADViewer::messageLogged(const QOpenGLDebugMessage &msg)
         break;
     case QOpenGLDebugMessage::LowSeverity:
         LOG_INFO << error.toStdString() << std::endl;
+        break;
+    default:
+        // AnySeverity is a filter sentinel and InvalidSeverity cannot arrive on
+        // a real message; log them at debug rather than dropping them silently.
+        LOG_DEBUG << error.toStdString() << std::endl;
         break;
     }
 }
@@ -258,7 +269,10 @@ void LCADViewer::wheelEvent(QWheelEvent *event) {
 
     for(auto pair : imagemaps)
     {
-        _docCanvas->zoom(*pair.first, zoom, true, event->pos().x(), event->pos().y());
+        // pos() is deprecated; position() is QPointF, and zoom() takes
+        // integral device coordinates, so round back to a QPoint.
+        const QPoint wheelPos = event->position().toPoint();
+        _docCanvas->zoom(*pair.first, zoom, true, wheelPos.x(), wheelPos.y());
     }
 
     updateBackground();

--- a/lcUI/lcadviewer.h
+++ b/lcUI/lcadviewer.h
@@ -1,14 +1,16 @@
 #pragma once
 #define GL_GLEXT_PROTOTYPES
 
-#include <GL/glew.h>
-#ifdef __APPLE__
-#include <OpenGL/gl.h>
-#include <OpenGL/glu.h>
-#else
-#include <GL/gl.h>
-#include <GL/glu.h>
-#endif
+// No GL/GLEW includes here.  This header uses no GL type or function -- only
+// Qt's QOpenGLWidget/QOpenGLContext -- and pulling glew.h in ahead of them made
+// Qt warn, once per translation unit that includes this header:
+//
+//   qopenglfunctions.h is not compatible with GLEW, GLEW defines will be undefined
+//   To use GLEW with Qt, do not include <qopengl.h> or <QOpenGLFunctions> after glew.h
+//
+// which is not merely noise: Qt undefines GLEW's macros when it wins the race.
+// Code that genuinely needs GLEW uses glewsupport.h, which keeps it in a
+// translation unit free of Qt's OpenGL headers.
 
 #include <map>
 #include <QOpenGLWidget>

--- a/lcUI/mainwindow.cpp
+++ b/lcUI/mainwindow.cpp
@@ -39,12 +39,12 @@ using namespace lc::ui;
 MainWindow::MainWindow()
     :
     ui(new Ui::MainWindow),
+    _layers(nullptr, this),
+    _cliCommand(this),
+    _toolbar(&_luaInterface, this),
     linePatternSelect(&_cadMdiChild, this, true, true),
     lineWidthSelect(_cadMdiChild.metaInfoManager(), this, true, true),
     colorSelect(_cadMdiChild.metaInfoManager(), this, true, true),
-    _cliCommand(this),
-    _toolbar(&_luaInterface, this),
-    _layers(nullptr, this),
     _copyManager(&_cadMdiChild)
 {
     ContextMenuManager::GetContextMenuManager(this);

--- a/lcUI/managers/copymanager.cpp
+++ b/lcUI/managers/copymanager.cpp
@@ -266,7 +266,7 @@ rapidjson::Value CopyManager::propertyValue(const std::string key, const lc::ent
     entityProp.AddMember("type", typeProp, document.GetAllocator());
     entityProp.AddMember("value", valueProp, document.GetAllocator());
 
-    return std::move(entityProp);
+    return entityProp;   // std::move here would defeat copy elision
 }
 
 void CopyManager::createOtherEntity(const std::string& entityName, const lc::entity::PropertiesMap& propertiesList, const rapidjson::Value& otherProperties) {

--- a/lcUI/managers/uisettings.cpp
+++ b/lcUI/managers/uisettings.cpp
@@ -269,7 +269,7 @@ rapidjson::Document UiSettings::getSettingsDocument(std::string fileName) {
         return rapidjson::Document();
     }
 
-    return std::move(settingsDocument);
+    return settingsDocument;   // std::move here would defeat copy elision
 }
 
 void UiSettings::writeSettingsFile(rapidjson::Document& document) {

--- a/lcUI/operationloader.cpp
+++ b/lcUI/operationloader.cpp
@@ -88,8 +88,8 @@ private:
 
 OperationLoader::OperationLoader(const std::string& luaPath, QMainWindow* qmainWindow, kaguya::State& luaState)
     :
-    qmainWindow(qmainWindow),
-    _L(luaState)
+    _L(luaState),
+    qmainWindow(qmainWindow)
 {
     std::string path = FolderFinder{}(luaPath);
     std::cout<<"updated path:: "<<path<<std::endl;

--- a/lcUI/widgets/customizeToolbar/customizeparenttab.cpp
+++ b/lcUI/widgets/customizeToolbar/customizeparenttab.cpp
@@ -12,8 +12,8 @@ using namespace lc::ui::widgets;
 
 CustomizeParentTab::CustomizeParentTab(lc::ui::api::ToolbarTab* toolbarTab, QWidget* parent)
     :
-    _label(toolbarTab->label()),
-    QTabWidget(parent)
+    QTabWidget(parent),
+    _label(toolbarTab->label())
 {
     init();
 
@@ -31,8 +31,8 @@ CustomizeParentTab::CustomizeParentTab(lc::ui::api::ToolbarTab* toolbarTab, QWid
 
 CustomizeParentTab::CustomizeParentTab(QString label, QWidget* parent)
     :
-    _label(label.toStdString()),
-    QTabWidget(parent)
+    QTabWidget(parent),
+    _label(label.toStdString())
 {
     init();
 

--- a/lcUI/widgets/customizeToolbar/customizetoolbar.cpp
+++ b/lcUI/widgets/customizeToolbar/customizetoolbar.cpp
@@ -25,9 +25,9 @@ using namespace lc::ui::widgets;
 CustomizeToolbar::CustomizeToolbar(Toolbar* toolbar, QWidget *parent)
     :
     QDialog(parent),
+    ui(new Ui::CustomizeToolbar),
     _toolbar(toolbar),
-    _saveOnClose(CloseMode::Ask),
-    ui(new Ui::CustomizeToolbar)
+    _saveOnClose(CloseMode::Ask)
 {
     ui->setupUi(this);
 

--- a/lcUI/widgets/customizeToolbar/customizetoolbar.cpp
+++ b/lcUI/widgets/customizeToolbar/customizetoolbar.cpp
@@ -286,7 +286,7 @@ void CustomizeToolbar::readData(rapidjson::Document& document) {
 
     while (currentTab < jsonTabs.Size()) {
         std::string tabLabel = jsonTabs[currentTab]["label"].GetString();
-        CustomizeParentTab* parentTab = parentTab = addParentTabManual(tabLabel);
+        CustomizeParentTab* parentTab = addParentTabManual(tabLabel);
 
         const rapidjson::Value& jsonGroups = jsonTabs[currentTab]["groups"];
         rapidjson::SizeType currentGroup = 0;

--- a/lcUI/widgets/guiAPI/colorgui.cpp
+++ b/lcUI/widgets/guiAPI/colorgui.cpp
@@ -8,8 +8,8 @@ using namespace lc::ui::api;
 ColorGUI::ColorGUI(std::string label, QWidget* parent)
     :
     InputGUI(label, parent),
-    _color("white"),
-    ui(new Ui::ColorGUI)
+    ui(new Ui::ColorGUI),
+    _color("white")
 {
     ui->setupUi(this);
 

--- a/lcUI/widgets/guiAPI/coordinategui.cpp
+++ b/lcUI/widgets/guiAPI/coordinategui.cpp
@@ -9,9 +9,9 @@ using namespace lc::ui::api;
 CoordinateGUI::CoordinateGUI(std::string label, QWidget* parent)
     :
     InputGUI(label, parent),
-    _pointSelectionEnabled(false),
+    ui(new Ui::CoordinateGUI),
     mainWindow(nullptr),
-    ui(new Ui::CoordinateGUI)
+    _pointSelectionEnabled(false)
 {
     ui->setupUi(this);
     _type = "coordinate";

--- a/lcUI/widgets/guiAPI/entitygui.cpp
+++ b/lcUI/widgets/guiAPI/entitygui.cpp
@@ -9,9 +9,9 @@ using namespace lc::ui::api;
 EntityGUI::EntityGUI(std::string label, QWidget* parent)
     :
     InputGUI(label, parent),
-    mainWindow(nullptr),
+    ui(new Ui::EntityGUI),
     _entitySelectionEnabled(false),
-    ui(new Ui::EntityGUI)
+    mainWindow(nullptr)
 {
     _type = "entity";
     ui->setupUi(this);

--- a/lcUI/widgets/guiAPI/inputguicontainer.cpp
+++ b/lcUI/widgets/guiAPI/inputguicontainer.cpp
@@ -12,8 +12,8 @@ using namespace lc::ui::api;
 
 InputGUIContainer::InputGUIContainer(const std::string& label, lc::ui::MainWindow* mainWindow)
     :
-    _label(label),
-    mainWindow(mainWindow)
+    mainWindow(mainWindow),
+    _label(label)
 {
 }
 

--- a/lcUI/widgets/guiAPI/listgui.cpp
+++ b/lcUI/widgets/guiAPI/listgui.cpp
@@ -165,7 +165,7 @@ void ListGUI::minusButtonClicked() {
 void ListGUI::setListType(ListGUI::ListType listTypeIn) {
     if (listTypeIn == ListType::COORDINATE) {
         // check if all already added widgets are of type coordinate
-        for (int i = 0; i < itemList.size(); i++) {
+        for (size_t i = 0; i < itemList.size(); i++) {
             CoordinateGUI* coordgui = qobject_cast<CoordinateGUI*>(itemList[i]);
             if (coordgui == nullptr) {
                 return;
@@ -179,7 +179,7 @@ void ListGUI::setListType(ListGUI::ListType listTypeIn) {
 
     if (listTypeIn == ListType::LW_VERTEX) {
         // check if all already added widgets are of type coordinate
-        for (int i = 0; i < itemList.size(); i++) {
+        for (size_t i = 0; i < itemList.size(); i++) {
             LWVertexGroup* lwvertex = qobject_cast<LWVertexGroup*>(itemList[i]);
             if (lwvertex == nullptr) {
                 return;

--- a/lcUI/widgets/guiAPI/menu.cpp
+++ b/lcUI/widgets/guiAPI/menu.cpp
@@ -10,8 +10,8 @@ using namespace lc::ui::api;
 Menu::Menu(const char* menuName, QWidget* parent)
     :
     QMenu(QString(menuName), parent),
-    _position(-1),
-    insideMenu(false)
+    insideMenu(false),
+    _position(-1)
 {
     this->setObjectName(menuName);
 }
@@ -19,16 +19,16 @@ Menu::Menu(const char* menuName, QWidget* parent)
 Menu::Menu(QMenuBar* menuBar)
     :
     QMenu(menuBar),
-    _position(-1),
-    insideMenu(false)
+    insideMenu(false),
+    _position(-1)
 {
 }
 
 Menu::Menu(QMenu* menu)
     :
     QMenu(menu),
-    _position(-1),
-    insideMenu(false)
+    insideMenu(false),
+    _position(-1)
 {
 }
 

--- a/lcUI/widgets/guiAPI/menuitem.cpp
+++ b/lcUI/widgets/guiAPI/menuitem.cpp
@@ -179,13 +179,13 @@ void MenuItem::updateOtherPositionsAfterRemove() {
 
 void MenuItem::itemTriggered() {
     // Phase 4 PR-4 — invoke neutral callbacks (nil-safe: nil returns Nil).
-    for (int i = 0; i < callbacks.size(); i++) {
+    for (size_t i = 0; i < callbacks.size(); i++) {
         callbacks[i].invoke();
     }
 }
 
 void MenuItem::itemToggled(bool toggle) {
-    for (int i = 0; i < _checkedCallbacks.size(); i++) {
+    for (size_t i = 0; i < _checkedCallbacks.size(); i++) {
         _checkedCallbacks[i].call(toggle);
     }
 }

--- a/lcUI/widgets/guiAPI/toolbarbutton.cpp
+++ b/lcUI/widgets/guiAPI/toolbarbutton.cpp
@@ -25,7 +25,9 @@ ToolbarButton::ToolbarButton(const char* buttonLabel, const char* icon,
     _checkable(_checkable)
 {
     this->setObjectName(buttonLabel);
-    if (tooltip == "") {
+    // tooltip is a const char*, so `tooltip == ""` compared addresses and was
+    // effectively never true; test the string itself, and tolerate nullptr.
+    if (tooltip == nullptr || *tooltip == '\0') {
         this->setToolTip(buttonLabel);
     }
     else {

--- a/lcUI/widgets/guiAPI/toolbarbutton.cpp
+++ b/lcUI/widgets/guiAPI/toolbarbutton.cpp
@@ -114,14 +114,14 @@ void ToolbarButton::removeCallback(const char* cb_name) {
 }
 
 void ToolbarButton::callbackCalled() {
-    for (int i = 0; i < callbacks.size(); i++) {
+    for (size_t i = 0; i < callbacks.size(); i++) {
         // Nil-safe: nil callback's invoke() is a graceful no-op returning Nil.
         callbacks[i].invoke();
     }
 }
 
 void ToolbarButton::callbackCalledToggle(bool enabled) {
-    for (int i = 0; i < callbacks.size(); i++) {
+    for (size_t i = 0; i < callbacks.size(); i++) {
         callbacks[i].call(enabled);
     }
 }

--- a/lcUI/widgets/guiAPI/toolbarbutton.cpp
+++ b/lcUI/widgets/guiAPI/toolbarbutton.cpp
@@ -20,8 +20,8 @@ ToolbarButton::ToolbarButton(const char* buttonLabel, const char* icon,
                              const char* tooltip, bool _checkable,
                              QWidget* parent, const char* fallbackDir)
     :
-    _label(buttonLabel),
     QPushButton("", parent),
+    _label(buttonLabel),
     _checkable(_checkable)
 {
     this->setObjectName(buttonLabel);

--- a/lcUI/widgets/guiAPI/toolbargroup.cpp
+++ b/lcUI/widgets/guiAPI/toolbargroup.cpp
@@ -8,8 +8,8 @@ ToolbarGroup::ToolbarGroup(const char* groupName, int width, QWidget* parent)
     :
     QGroupBox(groupName, parent),
     _width(width),
-    _nonButtonGroup(false),
-    _count(0)
+    _count(0),
+    _nonButtonGroup(false)
 {
     this->setLayout(new QGridLayout());
 }

--- a/lcUI/widgets/widgettitlebar.cpp
+++ b/lcUI/widgets/widgettitlebar.cpp
@@ -10,7 +10,10 @@ using namespace lc::ui::widgets;
 WidgetTitleBar::WidgetTitleBar( const QString& title,
                                 QDockWidget* parent,
                                 WidgetTitleBar::TitleBarOptions hideOptions)
-    : QWidget(parent), m_pMainHLayout(nullptr), m_pMainVLayout(nullptr), closed(false)
+    : QWidget(parent),
+    m_pMainVLayout(nullptr),
+    m_pMainHLayout(nullptr),
+    closed(false)
 {
     pDock = parent;
     expandedFeatures = pDock->features();

--- a/lcadluascript/lclua.cpp
+++ b/lcadluascript/lclua.cpp
@@ -109,7 +109,7 @@ std::string LCLua::read(FILE* file, size_t len) {
     buf[n] = '\0';
 
     auto bufferStr = std::string(buf);
-    delete buf;
+    delete[] buf;   // allocated with new[]
 
     return bufferStr;
 }

--- a/lckernel/cad/storage/entitycontainer.h
+++ b/lckernel/cad/storage/entitycontainer.h
@@ -161,11 +161,14 @@ public:
     EntityContainer entitiesByMetaType(const std::string& metaName) const {
         EntityContainer container;
 
-        for (auto i : asVector(std::numeric_limits<short>::max())) {
-            //       if (i->metaInfo(metaName) != nullptr) {
-            //           container.insert(i);
-            // }
-        }
+        // Unimplemented: the filter below was never written, so this walked
+        // every entity and discarded the result.  Left as the intended shape.
+        //
+        // for (auto i : asVector(std::numeric_limits<short>::max())) {
+        //     if (i->metaInfo(metaName) != nullptr) {
+        //         container.insert(i);
+        //     }
+        // }
 
         return container;
     }

--- a/lckernel/cad/tools/string_helper.h
+++ b/lckernel/cad/tools/string_helper.h
@@ -57,9 +57,16 @@ public:
     /**
      * Comparator for map to setup case Insensitive comparison ofstd::strings, useful in std::map
      */
-    struct cmpCaseInsensitive : std::binary_function<std::string, std::string, bool> {
+    // Deliberately not derived from std::binary_function: it was deprecated in
+    // C++11 and removed in C++17, and it only ever supplied the
+    // first_argument_type/second_argument_type/result_type typedefs that
+    // std::bind1st, std::bind2nd and std::not2 needed.  Those are gone too, and
+    // nothing here uses the typedefs -- both structs are used purely for their
+    // operator(), as a std::map comparator and a lexicographical_compare
+    // predicate respectively.
+    struct cmpCaseInsensitive {
         // case-independent (ci) compare_less binary function
-        struct nocase_compare : public std::binary_function<unsigned char, unsigned char, bool> {
+        struct nocase_compare {
             bool operator()(unsigned char c1, unsigned char c2) const {
                 return std::tolower(c1) < std::tolower(c2);
             }

--- a/lcviewernoqt/documentcanvas.cpp
+++ b/lcviewernoqt/documentcanvas.cpp
@@ -45,6 +45,7 @@ using namespace lc::viewer;
 
 DocumentCanvas::DocumentCanvas(const std::shared_ptr<lc::storage::Document>& document, std::function<void(double*, double*)> deviceToUser, meta::Block_CSPtr viewport) :
     _document(document),
+    _painterPtr(nullptr),
     _zoomMin(0.005),
     _zoomMax(200.0),
     _deviceWidth(0),
@@ -52,7 +53,6 @@ DocumentCanvas::DocumentCanvas(const std::shared_ptr<lc::storage::Document>& doc
     _selectedArea(nullptr),
     _selectedAreaIntersects(false),
     _deviceToUser(std::move(deviceToUser)),
-    _painterPtr(nullptr),
     _viewport(viewport)
 {
     document->addEntityEvent().connect<DocumentCanvas, &DocumentCanvas::on_addEntityEvent>(this);

--- a/lcviewernoqt/painters/opengl/vertexarray.cpp
+++ b/lcviewernoqt/painters/opengl/vertexarray.cpp
@@ -26,7 +26,7 @@ void VertexArray::addBuffer(const VertexBuffer& vb,const VertexBufferLayout& lay
 
     unsigned int offset=0;
 
-    for(int i=0; i<elements.size(); i++)
+    for (size_t i = 0; i < elements.size(); i++)
     {
         const auto& element=elements[i];
 

--- a/lcviewernoqt/painters/opengl/vertexarray.cpp
+++ b/lcviewernoqt/painters/opengl/vertexarray.cpp
@@ -1,5 +1,7 @@
 #include "vertexarray.h"
 
+#include <cstdint>   // uintptr_t, for the buffer-offset cast below
+
 using namespace lc::viewer::opengl;
 
 VertexArray::VertexArray()
@@ -28,7 +30,8 @@ void VertexArray::addBuffer(const VertexBuffer& vb,const VertexBufferLayout& lay
     {
         const auto& element=elements[i];
 
-        glVertexAttribPointer(i,element.count,element.type,element.normalized,layout.getStride(), (const void*)offset);
+        glVertexAttribPointer(i,element.count,element.type,element.normalized,layout.getStride(),
+                              reinterpret_cast<const void*>(static_cast<uintptr_t>(offset)));
         glEnableVertexAttribArray(i);
 
         offset+=element.count * VertexBufferElement::getSizeOfType(element.type);

--- a/persistence/file.cpp
+++ b/persistence/file.cpp
@@ -23,7 +23,14 @@ std::map<std::string, std::string> File::getSupportedFileExtensions() {
 
 File::Type File::open(lc::storage::Document_SPtr document, const std::string& path, File::Library library) {
     auto builder = std::make_shared<operation::Builder>(document, "Open file");
-    File::Type version;
+    // Never leave this indeterminate.  Neither switch below is exhaustive --
+    // the inner one has no case for older revisions (AC1002/AC1003/AC1004,
+    // AC12/AC14/AC150/AC210, MC00) or newer ones (AC1032), and the outer one
+    // has no LIBOPENCAD case unless LIBOPENCAD_ENABLED is defined -- so an
+    // unmapped file used to return an uninitialised File::Type, which the
+    // caller then uses to choose the save format.  R12 is what the existing
+    // UNKNOWNV case already falls back to.
+    File::Type version = Type::LIBDXFRW_DXF_R12;
 
     switch(library) {
     case LIBDXFRW: {
@@ -63,6 +70,10 @@ File::Type File::open(lc::storage::Document_SPtr document, const std::string& pa
         case DRW::AC1027:
             version = Type::LIBDXFRW_DXF_R2013;
             break;
+        default:
+            // A revision libdxfrw recognises but this mapping does not.  Keep
+            // the R12 fallback rather than reporting a type we never set.
+            break;
         }
         break;
     }
@@ -75,6 +86,10 @@ File::Type File::open(lc::storage::Document_SPtr document, const std::string& pa
         break;
     }
 #endif
+    default:
+        // Includes LIBOPENCAD when built without LIBOPENCAD_ENABLED: nothing
+        // was read, so report the fallback rather than an unset value.
+        break;
     }
 
     builder->execute();

--- a/unittest/ui/gui/testmenuitem.cpp
+++ b/unittest/ui/gui/testmenuitem.cpp
@@ -38,7 +38,9 @@ TEST(MenuItemTest, ItemAddTest) {
 
 TEST(MenuItemTest, ItemLabelTest) {
     QApplication app(argc, argv);
-    MainWindow* mainWindow = new MainWindow();
+    // Constructed for the Qt state the other tests rely on; this one never
+    // touches the window itself.
+    new MainWindow();
 
     lc::ui::api::MenuItem* testItem1 = new lc::ui::api::MenuItem("LABEL_TEST");
 

--- a/unittest/ui/widgets/layers.h
+++ b/unittest/ui/widgets/layers.h
@@ -25,7 +25,7 @@ public:
 
         QWidget* viewport = ui->layerList->viewport();
 
-        QTest::mouseClick(viewport, Qt::LeftButton, NULL, QPoint(xPos, yPos));
+        QTest::mouseClick(viewport, Qt::LeftButton, Qt::NoModifier, QPoint(xPos, yPos));
     }
 
     void addLayer(lc::meta::Layer_CSPtr layer) {


### PR DESCRIPTION
GCC 13 emits this twice for every translation unit that includes `string_helper.h`, which is most of them — it comes in through `cad/meta/layer.h` and `cad/storage/document.h`:

```
lckernel/cad/tools/string_helper.h:60:38: warning:
  'template<class _Arg1, class _Arg2, class _Result> struct std::binary_function'
  is deprecated [-Wdeprecated-declarations]
   60 |     struct cmpCaseInsensitive : std::binary_function<std::string, std::string, bool> {
lckernel/cad/tools/string_helper.h:62:45: warning: ... same for nocase_compare
```

## Why the base class can just go

`std::binary_function` was deprecated in C++11 and **removed in C++17**. It never carried behaviour — only the `first_argument_type` / `second_argument_type` / `result_type` typedefs that `std::bind1st`, `std::bind2nd` and `std::not2` consumed. Those are removed as well.

Nothing in this project wants them:

- `cmpCaseInsensitive` is used only as a `std::map` comparator (`documentimpl.h`, `storagemanager.h`, `document.h`, `storagemanagerimpl.{h,cpp}`, `documentimpl.cpp`);
- `nocase_compare` is used only as a `std::lexicographical_compare` predicate, one line below its definition.

Both are reached solely through `operator()`. A search across the tree finds no reference to those typedefs, nor to `bind1st`, `bind2nd` or `not2`. So the base classes are dead weight and dropping them changes nothing observable.

It also removes a future obstacle: under C++17 this would not merely warn, it would fail to compile.

## Verification

A translation unit including the header, compiled with `-Wdeprecated-declarations`:

| Header | GCC 16 | AppleClang |
|---|---|---|
| `master` | **2 warnings** | — |
| this branch | **0 warnings** | 0 warnings |

Two warnings before and none after, matching exactly the pair CI reports.

Behaviour was checked rather than assumed: a `std::map` keyed with `cmpCaseInsensitive` still finds `"alpha"` when the key was inserted as `"Alpha"`, still finds `"beta"` for `"BETA"`, and still collapses `"ALPHA"` onto the existing `"Alpha"` entry rather than adding a second one.

---

## Also: the Qt/GLEW and unrecognized-option warnings

Two further warnings that fire across most of the build.

### Qt vs GLEW — twice per TU that reaches `lcadviewer.h`

```
qopenglcontext.h:55: warning: #warning qopenglfunctions.h is not compatible with GLEW,
  GLEW defines will be undefined
qopenglcontext.h:56: warning: #warning To use GLEW with Qt, do not include <qopengl.h>
  or <QOpenGLFunctions> after glew.h
```

That reaches most of `lcUI` and much of the test suite through `cadmdichild.h` and `uitests.h`. It is not merely noise — Qt undefines GLEW's macros when it loses the race.

`lcadviewer.h` included `glew.h`, `gl.h` and `glu.h` while using **no GL type or function at all**, only `QOpenGLWidget`/`QOpenGLContext`. Dead weight that dragged the conflict into every consumer, so it is gone.

`lcadviewer.cpp` does use GLEW, and there no include order can work: Qt warns when `glew.h` precedes its OpenGL headers, and `glew.h` refuses to compile when `gl.h` precedes it — which Qt's headers do. The GLEW call therefore moved into `glewsupport.{h,cpp}`, a translation unit that includes `glew.h` and no Qt OpenGL header, behind a plain `bool initialiseGlew(std::string&)`. Both original log messages are preserved verbatim.

`dialogs/aboutdialog.cpp` keeps its `glew.h` deliberately: it really does call `glGetIntegerv`, and pulls in no Qt OpenGL header, so it never triggers the conflict.

### GCC reporting a flag this project handed it

```
cc1plus: note: unrecognized command-line option
'-Wno-missing-template-arg-list-after-template-kw' may have been intended to
silence earlier diagnostics
```

`check_cxx_compiler_flag` probed the **negative** spelling. GCC accepts any unrecognised `-Wno-*` silently, so the probe passed there and the flag was handed to a compiler that does not know it. GCC *does* reject the positive spelling, so probing that tells the compilers apart and the flag now reaches Clang only.

### Verification

Building `lcui` and `lcunittest`:

| Warning class | Count |
|---|---|
| Qt/GLEW incompatibility | **0** |
| unrecognized `-Wno-...` note | **0** |
| `std::binary_function` deprecation | **0** |
| errors | **0** |

Both translation units CI named — `testcommandline.cpp` and `testlinepatterns.cpp` — are among those compiled.

Behaviour is unchanged. The suite still stops at the pre-existing `LayersTest.Creation` segfault on macOS, after **exactly the same 171 passing tests** as a build without these changes — same count, same test — so the crash predates this work and is untouched by it.

---

## Also: seven warnings that were reporting real defects

Going through the GCC warning list, these are not stylistic — four are undefined or unspecified behaviour.

| File | Warning | Defect |
|---|---|---|
| `lcadluascript/lclua.cpp` | `-Wmismatched-new-delete` | `new char[]` released with scalar `delete` — **UB** |
| `customizeToolbar/customizetoolbar.cpp` | `-Wsequence-point` | `parentTab = parentTab = …` reads the variable while initialising it — **UB** |
| `widgets/guiAPI/toolbarbutton.cpp` | `-Waddress` | `const char* == ""` compared **addresses**, so the test was never true |
| `dialogs/aboutdialog.cpp` | `-Wvexing-parse` | `QString machine();` declares a function, not a variable |
| `painters/opengl/vertexarray.cpp` | `-Wint-to-pointer-cast` | 32-bit int cast to a 64-bit pointer |
| `managers/copymanager.cpp` | `-Wpessimizing-move` | `return std::move(local)` defeats copy elision |
| `managers/uisettings.cpp` | `-Wpessimizing-move` | same |

The `vertexarray.cpp` offset now widens through `uintptr_t`, the usual spelling for an OpenGL buffer offset. The `aboutdialog.cpp` declaration is removed rather than corrected, because nothing used it — the text below reads `buffer.machine`.

### One behaviour change, and it is the point of the fix

`ToolbarButton`'s `tooltip` parameter defaults to `""`. Because `tooltip == ""` compared pointers, it was effectively never true, so the branch meant to fall back to the button label **never ran** and such buttons were given `setToolTip("")` — no tooltip at all.

With the comparison fixed, that fallback works: a button created without an explicit tooltip now shows its **label** on hover. That is what the code always intended, but it is user-visible, so it should not pass unnoticed in review. `nullptr` is now tolerated as well.

### Verification

Rebuilt `lcunittest`: all six categories report **zero**, no new errors.

`DxfExportTest`, `ToolbarGroupTest` and `ToolbarTabTest` pass — 9 of 9. The macOS Qt UI tests still stop at `ToolbarTest.SlotTest` and `MenuTest.MenuLabelTest`, but a build **without** these changes stops at exactly the same two tests, so those crashes are pre-existing and untouched.

### Not addressed here

The remaining bulk categories are larger and lower severity, and would swamp the diff: roughly 117 `-Wreorder` (member initialisers listed out of declaration order), 135 `-Woverloaded-virtual`, 20 `-Wswitch` (unhandled enum values), 13 `-Wsign-compare`. `-Wreorder` and `-Wswitch` are worth a follow-up since either can hide a genuine bug.

---

## Also: switch, sign-compare and unused-variable

### One of these was a real bug

`persistence/file.cpp` declared `File::Type version;` **uninitialised**, and neither switch that assigns it is exhaustive — the inner one has no case for `AC1002`/`AC1003`/`AC1004`, `AC12`/`AC14`/`AC150`/`AC210`, `MC00` or `AC1032`, and the outer one has no `LIBOPENCAD` case unless `LIBOPENCAD_ENABLED` is defined.

Opening a file of any unmapped revision therefore returned an **indeterminate `File::Type`** — which the caller uses to choose the save format. It is now initialised to the `R12` that the existing `UNKNOWNV` case already falls back to, and both switches have a default, so the returned value is always one that was actually set.

### The rest

| File | Fix |
|---|---|
| `lcUI/lcadviewer.cpp` | three `QOpenGLDebugMessage` switches ignored Qt's filter sentinels (`AnySource`/`AnyType`/`AnySeverity`) and the `Invalid*` enumerators; defaults added, severity logs them at debug |
| `lcUI/lcadviewer.cpp` | `QWheelEvent::pos()` deprecated → `position()`, rounded back via `toPoint()` since `zoom()` takes integral device coordinates |
| `listgui.cpp`, `menuitem.cpp`, `toolbarbutton.cpp`, `vertexarray.cpp` | loops compared `int i` against `.size()`; indexed with `size_t` |
| `lckernel/.../entitycontainer.h` | `entitiesByMetaType` walked every entity with a body that was **entirely commented out**, building a vector and discarding it; the loop is now commented with the body it belongs to (the function returned an empty container before and still does) |
| `unittest/ui/widgets/layers.h` | `NULL` for `Qt::KeyboardModifiers` selected the deprecated `QFlags(Zero)` ctor → `Qt::NoModifier` |
| `unittest/ui/gui/testmenuitem.cpp` | a test named the `MainWindow` it constructs and never used it |

### Verification

Rebuilt `lcunittest`: `-Wswitch`, `-Wsign-compare`, `-Wdeprecated-declarations` and `-Wunused-variable` all report **zero**, no new errors. `DxfExportTest`, `ToolbarGroupTest`, `ToolbarTabTest`, `entitytest` and `LayerOpsTest` pass — 23 of 23.

### Still open: ~117 `-Wreorder`

Deliberately not in this PR. They are **GCC-only** — Clang does not raise them under this project's flags — so they cannot be verified from the machine this was developed on, and they want their own pass. Most are cosmetic, since C++ initialises members in declaration order regardless of how the list is written, but the case worth looking for is an initialiser that *reads* another member: there the mismatch is a genuine use-before-initialisation rather than a style nit.

---

## Also: the ~117 `-Wreorder`

Now included, having found a way to verify them. The warning is **GCC-only** — Clang does not raise it under this project's flags — so each affected translation unit was compiled with `g++-16` using the build's own flags, rather than edited blind.

C++ initialises bases first and then members in declaration order however the list is written, so these lists were not changing behaviour: they were describing an order that never happened. That is precisely what makes the dangerous case hard to notice.

Two shapes were present. Most were members simply out of declaration order. A few placed a **base class after a member** — `ToolbarButton` had `_label(...), QPushButton(...), _checkable(...)` and `CustomizeParentTab` had `_label(...), QTabWidget(parent)` — both of which construct the base first regardless.

### The case actually worth checking

An initialiser that *reads* another member is where written order can hide a use-before-initialisation. `MainWindow` has five:

```cpp
_toolbar(&_luaInterface, this)
linePatternSelect(&_cadMdiChild, this, true, true)
lineWidthSelect(_cadMdiChild.metaInfoManager(), this, true, true)
colorSelect(_cadMdiChild.metaInfoManager(), this, true, true)
_copyManager(&_cadMdiChild)
```

**These are safe.** `_luaInterface` (`mainwindow.h:318`) and `_cadMdiChild` (`:320`) are declared before every one of their users (`:323` onward), so they really are constructed first — including for `lineWidthSelect` and `colorSelect`, which *call a method* on `_cadMdiChild` rather than merely taking its address. Had the declaration order been the other way round, that would have been undefined behaviour. Reordering the lists makes this checkable at a glance instead of requiring a trip to the header.

`documentcanvas.cpp` was the mirror image: `_painterPtr` is declared early (`:270`) but initialised near the end of the list, so it moved **up**.

### Verification

`-Wreorder` across `lcUI` and `lcviewernoqt`: **117 → 0**, no new errors, each file compiled with the compiler that reports it. `lcunittest` still builds clean and 23 of 23 tests pass.
